### PR TITLE
fix!: use ISO 3166 standard for country codes

### DIFF
--- a/library_test.py
+++ b/library_test.py
@@ -28,7 +28,7 @@ def get_arguments() -> tuple[ArgumentParser, Namespace]:
         "-c",
         type=str,
         default="it",
-        help="Set Amazon login country",
+        help="Set Amazon login country (ISO3166 standard)",
     )
     parser.add_argument(
         "--email",

--- a/src/aioamazondevices/api.py
+++ b/src/aioamazondevices/api.py
@@ -28,7 +28,7 @@ from .const import (
     AMAZON_DEVICE_TYPE,
     DEFAULT_ASSOC_HANDLE,
     DEFAULT_HEADERS,
-    DOMAIN_BY_COUNTRY,
+    DOMAIN_BY_ISO3166_COUNTRY,
     HTML_EXTENSION,
     JSON_EXTENSION,
     NODE_BLUETOOTH,
@@ -72,7 +72,7 @@ class AmazonEchoApi:
         # Force country digits as lower case
         country_code = login_country_code.lower()
 
-        locale = DOMAIN_BY_COUNTRY.get(country_code)
+        locale = DOMAIN_BY_ISO3166_COUNTRY.get(country_code)
         domain = locale["domain"] if locale else country_code
 
         if locale and (assoc := locale.get("openid.assoc_handle")):

--- a/src/aioamazondevices/const.py
+++ b/src/aioamazondevices/const.py
@@ -6,12 +6,12 @@ _LOGGER = logging.getLogger(__package__)
 
 DEFAULT_ASSOC_HANDLE = "amzn_dp_project_dee_ios"
 
-DOMAIN_BY_COUNTRY = {
+DOMAIN_BY_ISO3166_COUNTRY = {
     "us": {
         "domain": "com",
         "openid.assoc_handle": DEFAULT_ASSOC_HANDLE,
     },
-    "uk": {
+    "gb": {
         "domain": "co.uk",
     },
     "au": {


### PR DESCRIPTION
Now library aders to ISO 3166 standard.

As a consequence, United Kingdom users should now use "**`GB`**" and no more "`UK`".