### PR TITLE
feat: allow easy swap of libraries

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,4 +3,5 @@ source = aioamazondevices
 omit =
     src/aioamazondevices/api.py
     src/aioamazondevices/exceptions.py
+    src/aioamazondevices/httpx.py
     library_test.py

--- a/poetry.lock
+++ b/poetry.lock
@@ -131,6 +131,28 @@ files = [
 frozenlist = ">=1.1.0"
 
 [[package]]
+name = "anyio"
+version = "4.9.0"
+description = "High level compatibility layer for multiple asynchronous event loop implementations"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "anyio-4.9.0-py3-none-any.whl", hash = "sha256:9f76d541cad6e36af7beb62e978876f3b41e3e04f2c1fbf0884604c0a9c4d93c"},
+    {file = "anyio-4.9.0.tar.gz", hash = "sha256:673c0c244e15788651a4ff38710fea9675823028a6f08a5eda409e0c9840a028"},
+]
+
+[package.dependencies]
+idna = ">=2.8"
+sniffio = ">=1.1"
+typing_extensions = {version = ">=4.5", markers = "python_version < \"3.13\""}
+
+[package.extras]
+doc = ["Sphinx (>=8.2,<9.0)", "packaging", "sphinx-autodoc-typehints (>=1.2.0)", "sphinx_rtd_theme"]
+test = ["anyio[trio]", "blockbuster (>=1.5.23)", "coverage[toml] (>=7)", "exceptiongroup (>=1.2.0)", "hypothesis (>=4.0)", "psutil (>=5.9)", "pytest (>=7.0)", "trustme", "truststore (>=0.9.1) ; python_version >= \"3.10\"", "uvloop (>=0.21) ; platform_python_implementation == \"CPython\" and platform_system != \"Windows\" and python_version < \"3.14\""]
+trio = ["trio (>=0.26.1)"]
+
+[[package]]
 name = "attrs"
 version = "25.3.0"
 description = "Classes Without Boilerplate"
@@ -187,6 +209,18 @@ chardet = ["chardet"]
 charset-normalizer = ["charset-normalizer"]
 html5lib = ["html5lib"]
 lxml = ["lxml"]
+
+[[package]]
+name = "certifi"
+version = "2025.4.26"
+description = "Python package for providing Mozilla's CA Bundle."
+optional = false
+python-versions = ">=3.6"
+groups = ["main"]
+files = [
+    {file = "certifi-2025.4.26-py3-none-any.whl", hash = "sha256:30350364dfe371162649852c63336a15c70c6510c2ad5015b21c2345311805f3"},
+    {file = "certifi-2025.4.26.tar.gz", hash = "sha256:0a816057ea3cdefcef70270d2c515e4506bbc954f417fa5ade2021213bb8f0c6"},
+]
 
 [[package]]
 name = "colorama"
@@ -408,6 +442,65 @@ files = [
     {file = "frozenlist-1.6.0-py3-none-any.whl", hash = "sha256:535eec9987adb04701266b92745d6cdcef2e77669299359c3009c3404dd5d191"},
     {file = "frozenlist-1.6.0.tar.gz", hash = "sha256:b99655c32c1c8e06d111e7f41c06c29a5318cb1835df23a45518e02a47c63b68"},
 ]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"},
+    {file = "h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1"},
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+description = "A minimal low-level HTTP client."
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55"},
+    {file = "httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8"},
+]
+
+[package.dependencies]
+certifi = "*"
+h11 = ">=0.16"
+
+[package.extras]
+asyncio = ["anyio (>=4.0,<5.0)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
+trio = ["trio (>=0.22.0,<1.0)"]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+description = "The next generation HTTP client."
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad"},
+    {file = "httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc"},
+]
+
+[package.dependencies]
+anyio = "*"
+certifi = "*"
+httpcore = "==1.*"
+idna = "*"
+
+[package.extras]
+brotli = ["brotli ; platform_python_implementation == \"CPython\"", "brotlicffi ; platform_python_implementation != \"CPython\""]
+cli = ["click (==8.*)", "pygments (==2.*)", "rich (>=10,<14)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
+zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "idna"
@@ -809,6 +902,18 @@ pytest = ">=4.6"
 testing = ["fields", "hunter", "process-tests", "pytest-xdist", "virtualenv"]
 
 [[package]]
+name = "sniffio"
+version = "1.3.1"
+description = "Sniff out which async library your code is running under"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2"},
+    {file = "sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"},
+]
+
+[[package]]
 name = "soupsieve"
 version = "2.7"
 description = "A modern CSS selector implementation for Beautiful Soup."
@@ -954,4 +1059,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "96d6c0c9876f1cba97c87cd45d2673f359945f85096fbf39a813eb1d968f7e38"
+content-hash = "f01f567e22776a3ebea3022e77e56268f843618ec7713fd70ab08e54692d8281"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ packages = [
 
 [tool.poetry.dependencies]
 aiohttp = "*"
+httpx = "*"
 python = "^3.12"
 babel = "*"
 beautifulsoup4 = "*"

--- a/src/aioamazondevices/httpx.py
+++ b/src/aioamazondevices/httpx.py
@@ -1,0 +1,159 @@
+"""Wrapper around httpx.Response to mimic aiohttp.ClientResponse."""
+
+import types
+from http.cookies import SimpleCookie
+from typing import Any, Self, cast
+
+from httpx import AsyncClient, Cookies, Response
+from httpx._types import RequestData
+
+
+def convert_httpx_cookies_to_simplecookie(httpx_cookies: Cookies) -> SimpleCookie:
+    """Convert an httpx.Cookies object to a single SimpleCookie."""
+    simple_cookie = SimpleCookie()
+
+    for name, value in httpx_cookies.items():
+        simple_cookie[name] = value
+
+    return simple_cookie
+
+
+class HttpxClientResponseWrapper:
+    """aiohttp-like Wrapper for httpx.Response."""
+
+    def __init__(self, response: Response) -> None:
+        """Init wrapper."""
+        self._response = response
+
+        # Basic aiohttp-like attributes
+        self.status = response.status_code
+        self.headers = response.headers
+        self.url = response.url
+        self.reason = response.reason_phrase
+        self.cookies = convert_httpx_cookies_to_simplecookie(response.cookies)
+        self.ok = response.is_success
+
+        # Aiohttp compatibility
+        self.content_type = response.headers.get("Content-Type", "")
+        self.real_url = str(response.url)
+        self.request_info = types.SimpleNamespace(
+            real_url=self.url,
+            method=response.request.method,
+            headers=response.request.headers,
+        )
+
+        # History (aiohttp returns redirects as history)
+        self.history = (
+            [HttpxClientResponseWrapper(r) for r in response.history]
+            if response.history
+            else []
+        )
+
+    async def text(self, encoding: str | None = None) -> str:
+        """Text."""
+        # httpx auto-decodes
+        if encoding:
+            return cast("str", self._response.content.decode(encoding))
+        return cast("str", self._response.text)
+
+    async def json(self) -> Any:  # noqa: ANN401
+        """Json."""
+        return self._response.json()
+
+    async def read(self) -> bytes:
+        """Read."""
+        return cast("bytes", self._response.content)
+
+    async def release(self) -> None:
+        """Release."""
+        # No-op: aiohttp requires this, httpx does not
+
+    def raise_for_status(self) -> Response:
+        """Raise for status."""
+        self._response.raise_for_status()
+
+    def __repr__(self) -> str:
+        """Repr."""
+        return f"<HttpxClientResponseWrapper [{self.status} {self.reason}]>"
+
+    async def __aenter__(self) -> Self:
+        """Aenter."""
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: types.TracebackType | None,
+    ) -> None:
+        """Aexit."""
+        await self.release()
+
+
+class HttpxClientSession:
+    """aiohttp-like Wrapper for httpx.AsyncClient."""
+
+    def __init__(self, **kwargs: Any) -> None:  # noqa: ANN401
+        """Init session."""
+        # Allow passing any httpx.AsyncClient init kwargs (e.g., headers, cookies)
+        self._client = AsyncClient(**kwargs)
+
+    @property
+    def closed(self) -> bool:
+        """Indicates whether the underlying client session is closed."""
+        return cast("bool", self._client.is_closed)
+
+    async def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        params: dict[str, str | int | float] | None = None,
+        data: Any = None,  # noqa: ANN401
+        json: Any = None,  # noqa: ANN401
+        **kwargs: Any,  # noqa: ANN401
+    ) -> HttpxClientResponseWrapper:
+        """Make a generic request method for any HTTP verb."""
+        response = await self._client.request(
+            method=method.upper(),
+            url=url,
+            params=params,
+            data=data,
+            json=json,
+            **kwargs,
+        )
+        return HttpxClientResponseWrapper(response)
+
+    async def get(self, url: str, **kwargs: Any) -> HttpxClientResponseWrapper:  # noqa: ANN401
+        """Get."""
+        response = await self._client.get(url, **kwargs)
+        return HttpxClientResponseWrapper(response)
+
+    async def post(
+        self,
+        url: str,
+        data: RequestData | None = None,
+        json: Any = None,  # noqa: ANN401
+        **kwargs: Any,  # noqa: ANN401
+    ) -> HttpxClientResponseWrapper:
+        """Post."""
+        response = await self._client.post(url, data=data, json=json, **kwargs)
+        return HttpxClientResponseWrapper(response)
+
+    async def close(self) -> None:
+        """Close."""
+        await self._client.aclose()
+
+    async def __aenter__(self) -> Self:
+        """AEnter."""
+        await self._client.__aenter__()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: types.TracebackType | None,
+    ) -> None:
+        """AExit."""
+        await self._client.__aexit__(exc_type, exc_val, exc_tb)

--- a/src/aioamazondevices/httpx.py
+++ b/src/aioamazondevices/httpx.py
@@ -70,7 +70,7 @@ class HttpxClientResponseWrapper:
 
     def raise_for_status(self) -> Response:
         """Raise for status."""
-        self._response.raise_for_status()
+        return self._response.raise_for_status()
 
     def __repr__(self) -> str:
         """Repr."""


### PR DESCRIPTION
Currently `aiohttp` is not working, while `httpx` is.

The purpose of this PR is to allow easy switching from one library to another, without touching the code but simply using the **LIBRARY** variable.

