### PR TITLE
fix: Add ecobee Switch+

### DIFF
--- a/src/aioamazondevices/const.py
+++ b/src/aioamazondevices/const.py
@@ -169,8 +169,8 @@ DEVICE_TYPE_TO_MODEL: dict[str, dict[str, str | None]] = {
         "hw_version": "Gen11",
     },
     "AUPUQSVCVHXP0": {
-        "manufacturer": "ecobee",
-        "model": "Switch+",
+        "manufacturer": "ecobee Inc.",
+        "model": "ecobee Switch+",
     },
     "AVU7CPPF2ZRAS": {
         "model": "Fire Tablet HD 8 Plus",

--- a/src/aioamazondevices/const.py
+++ b/src/aioamazondevices/const.py
@@ -168,6 +168,10 @@ DEVICE_TYPE_TO_MODEL: dict[str, dict[str, str | None]] = {
         "model": "Fire Tablet HD 10",
         "hw_version": "Gen11",
     },
+    "AUPUQSVCVHXP0": {
+        "manufacturer": "ecobee",
+        "model": "Switch+",
+    },
     "AVU7CPPF2ZRAS": {
         "model": "Fire Tablet HD 8 Plus",
         "hw_version": "Gen10",


### PR DESCRIPTION
With https://github.com/home-assistant/core/pull/146333 that is added to the milestone for the next release all the properties are optional so no need to specify hw_version. Specify the manufacturer so that it correctly shows in the UI as ecobee Switch+ by ecobee Inc. This is exactly how the same device is shown via the HomeKit integration.