### PR TITLE
fix: add ecobee switch+

### DIFF
--- a/src/aioamazondevices/const.py
+++ b/src/aioamazondevices/const.py
@@ -168,6 +168,10 @@ DEVICE_TYPE_TO_MODEL: dict[str, dict[str, str | None]] = {
         "model": "Fire Tablet HD 10",
         "hw_version": "Gen11",
     },
+    "AUPUQSVCVHXP0": {
+        "manufacturer": "ecobee Inc.",
+        "model": "ecobee Switch+",
+    },
     "AVU7CPPF2ZRAS": {
         "model": "Fire Tablet HD 8 Plus",
         "hw_version": "Gen10",

--- a/src/aioamazondevices/const.py
+++ b/src/aioamazondevices/const.py
@@ -171,6 +171,7 @@ DEVICE_TYPE_TO_MODEL: dict[str, dict[str, str | None]] = {
     "AUPUQSVCVHXP0": {
         "manufacturer": "ecobee Inc.",
         "model": "ecobee Switch+",
+        "hw_version": None,
     },
     "AVU7CPPF2ZRAS": {
         "model": "Fire Tablet HD 8 Plus",


### PR DESCRIPTION
Specify the manufacturer so that it correctly shows in the UI as ecobee Switch+ by ecobee Inc. This is exactly how the same device is shown via the HomeKit integration.