### PR TITLE
fix: add sensors only for linked devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v3.1.3-rc.1 (2025-06-14)
+
+### Bug fixes
+
+- Add sensors only for linked devices ([`528c466`](https://github.com/chemelli74/aioamazondevices/commit/528c466c8ed685453df48167fa17eee46c8cd26f))
+
+
 ## v3.1.2 (2025-06-13)
 
 ### Bug fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aioamazondevices"
-version = "3.1.2"
+version = "3.1.3-rc.1"
 description = "Python library to control Amazon devices"
 authors = ["Simone Chemelli <simone.chemelli@gmail.com>"]
 license = "Apache-2.0"

--- a/src/aioamazondevices/__init__.py
+++ b/src/aioamazondevices/__init__.py
@@ -1,6 +1,6 @@
 """aioamazondevices library."""
 
-__version__ = "3.1.2"
+__version__ = "3.1.3-rc.1"
 
 
 from .api import AmazonDevice, AmazonEchoApi

--- a/src/aioamazondevices/api.py
+++ b/src/aioamazondevices/api.py
@@ -538,7 +538,9 @@ class AmazonEchoApi:
                 serial_number = device_identifier["dmsDeviceSerialNumber"]
 
                 # Add identifier information to the device
-                self._devices[serial_number] |= {NODE_IDENTIFIER: identifier}
+                # but only if the device was previously found
+                if serial_number in self._devices:
+                    self._devices[serial_number] |= {NODE_IDENTIFIER: identifier}
 
             # Add to entity IDs list for sensor retrieval
             entity_ids_list.append({"entityId": entity_id, "entityType": "ENTITY"})


### PR DESCRIPTION
Some devices report their state via `/api/phoenix/state` even if they are not linked to the Amazon account.
