### PR TITLE
fix: correct check for 404, and save response before checking for errors for easy debug

### DIFF
--- a/src/aioamazondevices/api.py
+++ b/src/aioamazondevices/api.py
@@ -295,8 +295,8 @@ class AmazonEchoApi:
         """Return true if error is due to /ap/signin endpoint."""
         # Endpoint 'ap/signin' replies with error 404
         # but reports the needed parameters anyway
-        return (
-            response.status == HTTPStatus.NOT_FOUND and ("/ap/signin" in url or "/ap/sigin" in url)
+        return response.status == HTTPStatus.NOT_FOUND and (
+            "/ap/signin" in url or "/ap/sigin" in url
         )
 
     async def _session_request(
@@ -354,7 +354,7 @@ class AmazonEchoApi:
             await resp.text(),
             url,
             mimetypes.guess_extension(content_type.split(";")[0]) or ".raw",
-            resp=resp
+            resp=resp,
         )
 
         if resp.status != HTTPStatus.OK:
@@ -383,7 +383,7 @@ class AmazonEchoApi:
         url: str,
         extension: str = HTML_EXTENSION,
         output_path: str = SAVE_PATH,
-        resp: ClientResponse = None
+        resp: ClientResponse = None,
     ) -> None:
         """Save response data to disk."""
         if not self._save_raw_data or not raw_data:
@@ -423,13 +423,15 @@ class AmazonEchoApi:
             file.write("\n")
 
         if resp:
-           with Path.open(str(fullpath) + ".response", mode="w", encoding="utf-8") as file:
-             file.write(str(resp.status) + "\n")
-             file.write("Headers: \n")             
-             for name, value in resp.headers.items():
-                 file.write(f"\t{name}: {value}\n")
-                 
-             # The response data is alredy saved on other file
+            with Path.open(
+                str(fullpath) + ".response", mode="w", encoding="utf-8"
+            ) as file:
+                file.write(str(resp.status) + "\n")
+                file.write("Headers: \n")
+                for name, value in resp.headers.items():
+                    file.write(f"\t{name}: {value}\n")
+
+                # The response data is alredy saved on other file
 
     async def _register_device(
         self,

--- a/src/aioamazondevices/api.py
+++ b/src/aioamazondevices/api.py
@@ -431,7 +431,7 @@ class AmazonEchoApi:
                 for name, value in resp.headers.items():
                     file.write(f"\t{name}: {value}\n")
 
-                # The response data is alredy saved on other file
+                # The response data is already saved on other file
 
     async def _register_device(
         self,


### PR DESCRIPTION
I started getting the 404 error and cannot login after the await inclusion.

I found what I think was typo and also the checking for url using response.url was not working.

Also moved the save response before checking.

If there was a typo as I asked on https://github.com/chemelli74/aioamazondevices/issues/279 we can remove the check for "/sigin" and keep only check for "/signin"

With this changce I was able to login again in my account that I cannot login on latest releases.
