### PR TITLE
fix: add more countries settings

### DIFF
--- a/src/aioamazondevices/const.py
+++ b/src/aioamazondevices/const.py
@@ -19,6 +19,9 @@ DOMAIN_BY_ISO3166_COUNTRY = {
         "domain": "com.au",
         "openid.assoc_handle": DEFAULT_ASSOC_HANDLE,
     },
+    "be": {
+        "domain": "com.be",
+    },
     "br": {
         "domain": "com.br",
     },
@@ -32,6 +35,9 @@ DOMAIN_BY_ISO3166_COUNTRY = {
     "nz": {
         "domain": "com.au",
         "openid.assoc_handle": DEFAULT_ASSOC_HANDLE,
+    },
+    "tr": {
+        "domain": "com.tr",
     },
     "us": {
         "domain": "com",


### PR DESCRIPTION
Add more specific Amazon domains based on [List of country-specific domains for Amazon.com](https://gist.github.com/noraworld/0ee7af8b6b068d5d7b6d97caded18bab#list-of-country-specific-domains-for-amazoncom)