### PR TITLE
fix: add Israel domain settings

### DIFF
--- a/src/aioamazondevices/const.py
+++ b/src/aioamazondevices/const.py
@@ -48,6 +48,10 @@ DOMAIN_BY_ISO3166_COUNTRY = {
         "domain": "co.uk",
         "openid.assoc_handle": f"{DEFAULT_ASSOC_HANDLE}_uk",
     },
+    "il": {
+        "domain": "com",
+        "openid.assoc_handle": DEFAULT_ASSOC_HANDLE,
+    },
     "jp": {
         "domain": "co.jp",
     },


### PR DESCRIPTION
`python library_test.py ` works ok, but fails on another [429 rate limit issue](https://github.com/chemelli74/aioamazondevices/issues/307)