### PR TITLE
chore: cleanup redundant output

### DIFF
--- a/src/aioamazondevices/api.py
+++ b/src/aioamazondevices/api.py
@@ -479,11 +479,6 @@ class AmazonEchoApi:
             )
             raise CannotRegisterDevice(f"{HTTPStatus(resp.status).phrase}: {msg}")
 
-        await self._save_to_file(
-            await resp.text(),
-            url=register_url,
-            extension=JSON_EXTENSION,
-        )
         success_response = resp_json["response"]["success"]
 
         tokens = success_response["tokens"]


### PR DESCRIPTION
Just cleanup redundant output which is already saved in  `_session_request` call preceeding this