### PR TITLE
fix: update openid.assoc_handle for AU and NZ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v3.3.1-rc.1 (2025-07-15)
+
+### Bug fixes
+
+- Update openid.assoc_handle for aus/nz ([`e8aded2`](https://github.com/chemelli74/aioamazondevices/commit/e8aded246020be4b415a5598733470fc3d8166b3))
+
+
 ## v3.3.0 (2025-07-14)
 
 ### Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aioamazondevices"
-version = "3.3.0"
+version = "3.3.1-rc.1"
 requires-python = ">=3.12"
 description = "Python library to control Amazon devices"
 authors = [

--- a/src/aioamazondevices/__init__.py
+++ b/src/aioamazondevices/__init__.py
@@ -1,6 +1,6 @@
 """aioamazondevices library."""
 
-__version__ = "3.3.0"
+__version__ = "3.3.1-rc.1"
 
 
 from .api import AmazonDevice, AmazonEchoApi

--- a/src/aioamazondevices/const.py
+++ b/src/aioamazondevices/const.py
@@ -42,7 +42,7 @@ DOMAIN_BY_ISO3166_COUNTRY = {
     },
     "au": {
         "domain": "com.au",
-        "openid.assoc_handle": DEFAULT_ASSOC_HANDLE,
+        "openid.assoc_handle": f"{DEFAULT_ASSOC_HANDLE}_au",
     },
     "be": {
         "domain": "com.be",
@@ -66,7 +66,7 @@ DOMAIN_BY_ISO3166_COUNTRY = {
     },
     "nz": {
         "domain": "com.au",
-        "openid.assoc_handle": DEFAULT_ASSOC_HANDLE,
+        "openid.assoc_handle": f"{DEFAULT_ASSOC_HANDLE}_au",
     },
     "tr": {
         "domain": "com.tr",


### PR DESCRIPTION
https://github.com/home-assistant/core/issues/148780
https://github.com/home-assistant/core/issues/148777
need to update `openid.assoc_handle` for Australia and New Zealand