### PR TITLE
fix: using default=True test cannot be disabled

### DIFF
--- a/library_test.py
+++ b/library_test.py
@@ -159,7 +159,10 @@ async def main() -> None:
     login_data_stored = read_from_file(args.login_data_file)
 
     if not login_data_stored and not args.password:
-        print("You have to specify credentials for ", args.email if sys.stdout.isatty() else obfuscate_email(args.email))
+        print(
+            "You have to specify credentials for ",
+            args.email if sys.stdout.isatty() else obfuscate_email(args.email),
+        )
         args.password = getpass.getpass("Password: ")
 
     api = AmazonEchoApi(
@@ -197,7 +200,9 @@ async def main() -> None:
     print("Logged-in.")
 
     print("-" * 20)
-    print("Login data:", login_data if sys.stdout.isatty() else scrub_fields(login_data))
+    print(
+        "Login data:", login_data if sys.stdout.isatty() else scrub_fields(login_data)
+    )
     print("-" * 20)
 
     save_to_file(f"{SAVE_PATH}/output-login-data.json", login_data)

--- a/library_test.py
+++ b/library_test.py
@@ -65,7 +65,6 @@ def get_arguments() -> tuple[ArgumentParser, Namespace]:
         "--save_raw_data",
         "-s",
         action="store_true",
-        default=True,
         help="Save HTML source on disk",
     )
     parser.add_argument(
@@ -73,6 +72,12 @@ def get_arguments() -> tuple[ArgumentParser, Namespace]:
         "-t",
         action="store_true",
         help="Execute test actions",
+    )
+    parser.add_argument(
+        "--login_only",
+        "-l",
+        action="store_true",
+        help="Only login without doing other actions",
     )
     parser.add_argument(
         "--configfile",
@@ -196,6 +201,11 @@ async def main() -> None:
 
     save_to_file(f"{SAVE_PATH}/output-login-data.json", login_data)
 
+    if args.login_only:
+        print("!!! Login only requested, exiting !!!")
+        await api.close()
+        sys.exit(0)
+        
     print("-" * 20)
     try:
         devices = await api.get_devices_data()

--- a/library_test.py
+++ b/library_test.py
@@ -72,7 +72,6 @@ def get_arguments() -> tuple[ArgumentParser, Namespace]:
         "--test",
         "-t",
         action="store_true",
-        default=True,
         help="Execute test actions",
     )
     parser.add_argument(

--- a/library_test.py
+++ b/library_test.py
@@ -22,6 +22,7 @@ from aioamazondevices.exceptions import (
     CannotRegisterDevice,
     WrongCountry,
 )
+from aioamazondevices.utils import obfuscate_email, scrub_fields
 
 
 def get_arguments() -> tuple[ArgumentParser, Namespace]:
@@ -158,7 +159,7 @@ async def main() -> None:
     login_data_stored = read_from_file(args.login_data_file)
 
     if not login_data_stored and not args.password:
-        print(f"You have to specify credentials for {args.email}")
+        print("You have to specify credentials for ", args.email if sys.stdout.isatty() else obfuscate_email(args.email))
         args.password = getpass.getpass("Password: ")
 
     api = AmazonEchoApi(
@@ -196,7 +197,7 @@ async def main() -> None:
     print("Logged-in.")
 
     print("-" * 20)
-    print("Login data:", login_data)
+    print("Login data:", login_data if sys.stdout.isatty() else scrub_fields(login_data))
     print("-" * 20)
 
     save_to_file(f"{SAVE_PATH}/output-login-data.json", login_data)


### PR DESCRIPTION
The current option are enabled by default and cannot be disabled, the store_true action will put True again and cant be disabled.

This make easier for testing the login process only without testing the devices when not need.
