### PR TITLE
feat: add media controls

### DIFF
--- a/library_test.py
+++ b/library_test.py
@@ -272,6 +272,24 @@ async def main() -> None:
 
     await wait_action_complete(15)
 
+    print(f"Pausing track on {device_single.account_name}")
+    await api.media_pause(device_single)
+    await wait_action_complete(8)
+
+    print(f"Play track on {device_single.account_name}")
+    await api.media_play(device_single)
+    await wait_action_complete()
+
+    print(f"Skipping to next track on {device_single.account_name}")
+    await api.media_next(device_single)
+    await wait_action_complete(15)
+
+    await wait_action_complete()
+
+    music = "taylor swift"
+    print(f"Playing {music} from {source} on {device_single.account_name}")
+    await api.call_alexa_music(device_single, music, source)
+
     print(f"Text command on {device_single.account_name}")
     await api.call_alexa_text_command(device_single, "Set timer pasta 12 minute")
 

--- a/src/aioamazondevices/api.py
+++ b/src/aioamazondevices/api.py
@@ -107,6 +107,7 @@ class AmazonSequenceType(StrEnum):
     Music = "Alexa.Music.PlaySearchPhrase"
     TextCommand = "Alexa.TextCommand"
     LaunchSkill = "Alexa.Operation.SkillConnections.Launch"
+    Stop = "Alexa.DeviceControls.Stop"
 
 
 class AmazonMusicSource(StrEnum):
@@ -1033,6 +1034,17 @@ class AmazonEchoApi:
                     "uri": "connection://AMAZON.Launch/" + message_body,
                 },
             }
+        elif message_type == AmazonSequenceType.Stop:
+            payload = {
+                **base_payload,
+                "devices": [
+                    {
+                        "deviceSerialNumber": device.serial_number,
+                        "deviceType": device.device_type,
+                    },
+                ],
+                "skillId": "amzn1.ask.1p.alexadevicecontrols",
+            }
         else:
             raise ValueError(f"Message type <{message_type}> is not recognised")
 
@@ -1134,3 +1146,72 @@ class AmazonEchoApi:
         await self._session_request(
             method="PUT", url=url, input_data=payload, json_data=True
         )
+
+    async def call_devicecontrols_stop(
+        self,
+        device: AmazonDevice,
+    ) -> None:
+        """Call Alexa.DeviceControls.Stop to stop playback."""
+        return await self._send_message(device, AmazonSequenceType.Stop, "")
+
+    # region Media Controls
+
+    async def _media_command(
+        self, device: AmazonDevice, command: dict[str, Any]
+    ) -> None:
+        await self._session_request(
+            method=HTTPMethod.POST,
+            url=f"https://alexa.amazon.{self._domain}/api/np/command?deviceSerialNumber={device.serial_number}&deviceType={device.device_type}",
+            input_data=command,
+            json_data=True,
+        )
+
+    async def media_play(
+        self,
+        device: AmazonDevice,
+    ) -> None:
+        """Media Player play."""
+        command = {"type": "PlayCommand"}
+        await self._media_command(device, command)
+
+    async def media_pause(
+        self,
+        device: AmazonDevice,
+    ) -> None:
+        """Media Player pause."""
+        command = {"type": "PauseCommand"}
+        await self._media_command(device, command)
+
+    async def media_prev(
+        self,
+        device: AmazonDevice,
+    ) -> None:
+        """Media Player previous."""
+        command = {"type": "PreviousCommand"}
+        await self._media_command(device, command)
+
+    async def media_next(
+        self,
+        device: AmazonDevice,
+    ) -> None:
+        """Media Player next."""
+        command = {"type": "NextCommand"}
+        await self._media_command(device, command)
+
+    async def media_rewind(
+        self,
+        device: AmazonDevice,
+    ) -> None:
+        """Media Player rewind."""
+        command = {"type": "RewindCommand"}
+        await self._media_command(device, command)
+
+    async def media_fast_forward(
+        self,
+        device: AmazonDevice,
+    ) -> None:
+        """Media Player fast forward."""
+        command = {"type": "ForwardCommand"}
+        await self._media_command(device, command)
+
+    # endregion


### PR DESCRIPTION
There are a few controls not in tests as they aren't available for all providers.
Play, Next, Stop are pretty much supported by all.

As these become device control methods I wasn't sure whether `AmazonDevice` should actually become a concrete class in it's own file rather than being a `dataClass` with device specific methods at the API level ??