### PR TITLE
chore: follow up of #443

### DIFF
--- a/src/aioamazondevices/api.py
+++ b/src/aioamazondevices/api.py
@@ -589,7 +589,7 @@ class AmazonEchoApi:
 
         if amazon_market not in self._market:
             _LOGGER.warning(
-                "Selected country <%s> doesn't matches Amazon API reply:\n%s\n vs \n%s",
+                "Selected country <%s> doesn't match Amazon API reply:\n%s\n vs \n%s",
                 self._login_country_code.upper(),
                 {"input ": self._market},
                 {"amazon": amazon_market},


### PR DESCRIPTION
Missed from 442/443 `!`= need to be `not in`
Also updated typo