### PR TITLE
fix: standardise locale

### DIFF
--- a/src/aioamazondevices/api.py
+++ b/src/aioamazondevices/api.py
@@ -22,7 +22,7 @@ from aiohttp import (
     ClientSession,
 )
 from bs4 import BeautifulSoup, Tag
-from langcodes import Language
+from langcodes import Language, standardize_tag
 from multidict import MultiDictProxy
 from yarl import URL
 
@@ -171,7 +171,8 @@ class AmazonEchoApi:
         lang_maximized = lang_object.maximize()
 
         self._domain: str = domain
-        self._language = f"{lang_maximized.language}-{lang_maximized.region}"
+        language = f"{lang_maximized.language}-{lang_maximized.territory}"
+        self._language = standardize_tag(language)
 
         # Reset CSRF cookie when changing country
         self._csrf_cookie: str | None = None


### PR DESCRIPTION
Current code results in `en-UK` (region is deprecated in `langcodes` and returns `territory` which is what is being passed in to start with).

UK is probably the only country where domain <> ISO country code so not sure it it is simpler to treat this as we do matching `com` to US ??