### PR TITLE
build: fix checkout for PR from forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,11 +78,13 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v5
+      # Checkout must work for both PRs (including forks) and pushes to main
+      - name: Checkout code
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
 
       # Do a dry run of PSR
       - name: Test release
@@ -99,7 +101,7 @@ jobs:
       - name: Release
         uses: python-semantic-release/python-semantic-release@v10.4.1
         id: release
-        if: github.ref_name == 'main'
+        if: github.event_name == 'push' && github.ref_name == 'main'
         with:
           verbosity: 2 # equivalent to "-vv"
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now handles pull-request vs push events so preview runs use the PR source when appropriate.
  * Dry-run release previews continue to run for PRs to show versioning and notes without publishing.
  * Actual release publishing is restricted to pushes on the main branch; publish steps run only when a release is produced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->