### PR TITLE
fix: log response content on error

### DIFF
--- a/src/aioamazondevices/http_wrapper.py
+++ b/src/aioamazondevices/http_wrapper.py
@@ -369,12 +369,10 @@ class AmazonHttpWrapper:
             ]:
                 raise CannotAuthenticate(await self.http_phrase_error(resp.status))
             if not await self._ignore_ap_signin_error(resp):
-                try:
-                    _LOGGER.debug("Error response content: %s", await resp.text())
-                finally:
-                    raise CannotRetrieveData(
-                        f"Request failed: {await self.http_phrase_error(resp.status)}"
-                    )
+                _LOGGER.debug("Error response content: %s", await resp.text())
+                raise CannotRetrieveData(
+                    f"Request failed: {await self.http_phrase_error(resp.status)}"
+                )
 
         raw_content = await resp.read()
 


### PR DESCRIPTION
Was looking at the notification / 400 response issue and realised we never log the actual response.

Added debug logging where response fails to attempt to output actual content

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostic logging for authentication/sign-in failures so response details are captured at debug level before the error is surfaced, aiding troubleshooting and support.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->