### PR TITLE
fix: ignore non amazon aqm devices

### DIFF
--- a/src/aioamazondevices/api.py
+++ b/src/aioamazondevices/api.py
@@ -295,6 +295,17 @@ class AmazonEchoApi:
         # map endpoint ID to serial number to facilitate sensor lookup but also
         # create AmazonDevice as these are not present in api/devices-v2/device endpoint
         for aqm_endpoint in data.get("airQualityMonitors", {}).get("endpoints", {}):
+            if (
+                aqm_endpoint.get("manufacturer", {})
+                .get("value", {})
+                .get("text", "Unknown")
+                != "Amazon"
+            ):
+                _LOGGER.debug(
+                    "Skipping non-Amazon Air Quality Monitor: %s",
+                    aqm_endpoint,
+                )
+                continue
             aqm_serial_number: str = aqm_endpoint["serialNumber"]["value"]["text"]
             devices_endpoints[aqm_serial_number] = aqm_endpoint
             self._endpoints[aqm_endpoint["endpointId"]] = aqm_serial_number


### PR DESCRIPTION
fix for https://github.com/home-assistant/core/issues/16230

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Air quality monitors from non-Amazon manufacturers are now filtered during device initialization, ensuring only Amazon-compatible monitors are processed in your setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->