### PR TITLE
fix!: allow overwrite for default login site

### DIFF
--- a/library_test.py
+++ b/library_test.py
@@ -18,13 +18,18 @@ from colorlog import ColoredFormatter
 
 from aioamazondevices.api import AmazonEchoApi
 from aioamazondevices.const.devices import AQM_DEVICE_TYPE
+from aioamazondevices.const.http import DEFAULT_SITE
 from aioamazondevices.exceptions import (
     AmazonError,
     CannotAuthenticate,
     CannotConnect,
     CannotRegisterDevice,
 )
-from aioamazondevices.structures import AmazonDevice, AmazonMusicSource
+from aioamazondevices.structures import (
+    AmazonCredentials,
+    AmazonDevice,
+    AmazonMusicSource,
+)
 
 SAVE_PATH = "out"
 HTML_EXTENSION = ".html"
@@ -42,6 +47,9 @@ async def get_arguments() -> tuple[ArgumentParser, Namespace]:
         help="Set Amazon login e-mail",
     )
     parser.add_argument("--password", "-p", type=str, help="Set Amazon login password")
+    parser.add_argument(
+        "--site", "-s", type=str, default=DEFAULT_SITE, help="Set Amazon login site"
+    )
     parser.add_argument("--otp_code", "-o", type=str, help="Set Amazon OTP code")
     parser.add_argument(
         "--login_data_file",
@@ -194,8 +202,11 @@ async def main() -> None:
 
     api = AmazonEchoApi(
         client_session=client_session,
-        login_email=args.email,
-        login_password=args.password,
+        credentials=AmazonCredentials(
+            site=args.site or login_data_stored.get("site", DEFAULT_SITE),
+            login=args.email,
+            password=args.password,
+        ),
         login_data=login_data_stored,
         save_to_file=save_to_file,
     )

--- a/src/aioamazondevices/api.py
+++ b/src/aioamazondevices/api.py
@@ -37,6 +37,7 @@ from .implementation.notification import AmazonNotificationHandler
 from .implementation.sequence import AmazonSequenceHandler
 from .login import AmazonLogin
 from .structures import (
+    AmazonCredentials,
     AmazonDevice,
     AmazonDeviceSensor,
     AmazonMusicSource,
@@ -51,8 +52,7 @@ class AmazonEchoApi:
     def __init__(
         self,
         client_session: ClientSession,
-        login_email: str,
-        login_password: str,
+        credentials: AmazonCredentials,
         login_data: dict[str, Any] | None = None,
         save_to_file: Callable[[str | dict, str, str], Coroutine[Any, Any, None]]
         | None = None,
@@ -61,11 +61,14 @@ class AmazonEchoApi:
         _LOGGER.debug("Initialize library v%s", __version__)
 
         # Check if there is a previous login, otherwise use default (US)
-        site = login_data.get("site", DEFAULT_SITE) if login_data else DEFAULT_SITE
+        site = login_data.get("site", DEFAULT_SITE) if login_data else credentials.site
         _LOGGER.debug("Using site: %s", site)
 
         self._session_state_data = AmazonSessionStateData(
-            site, login_email, login_password, login_data
+            site,
+            credentials.login,
+            credentials.password,
+            login_data,
         )
 
         self._http_wrapper = AmazonHttpWrapper(

--- a/src/aioamazondevices/structures.py
+++ b/src/aioamazondevices/structures.py
@@ -6,6 +6,15 @@ from enum import StrEnum
 
 
 @dataclass
+class AmazonCredentials:
+    """Amazon credentials class."""
+
+    login: str
+    password: str
+    site: str
+
+
+@dataclass
 class AmazonDeviceSensor:
     """Amazon device sensor class."""
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --site (-s) command-line option to select the Amazon login site.
  * Introduced a public credentials data structure to hold site, login and password.

* **Refactor**
  * Authentication flow updated to accept a credentials object (site/login/password) instead of separate email/password parameters; defaults to the stored site or configured default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->