### PR TITLE
fix!: move speaker group device type to const

### DIFF
--- a/src/aioamazondevices/const/devices.py
+++ b/src/aioamazondevices/const/devices.py
@@ -4,9 +4,10 @@ from .http import AMAZON_DEVICE_TYPE
 
 SPEAKER_GROUP_FAMILY = "WHA"
 AQM_DEVICE_TYPE = "AEZME1X38KDRA"
+SPEAKER_GROUP_DEVICE_TYPE = "A3C9PE6TNYLTCH"
 
 DEVICE_HARDCODED_DATA: dict[str, dict[str, str]] = {
-    "A3C9PE6TNYLTCH": {
+    SPEAKER_GROUP_DEVICE_TYPE: {
         "model": "Speaker Group",
         "manufacturer": "Amazon",
     },


### PR DESCRIPTION
Follow-up of #563 

Device model data is now fetched from Amazon instead of hard-coded values, without the need of keeping track of all possible models.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Introduced a public constant for speaker group device type identifier, replacing hardcoded values in device configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->