### PR TITLE
refactor: clarify const name

### DIFF
--- a/src/aioamazondevices/api.py
+++ b/src/aioamazondevices/api.py
@@ -10,8 +10,8 @@ from aiohttp import ClientSession
 from . import __version__
 from .const.devices import (
     DEVICE_TYPE_AQM,
-    DEVICE_TYPE_TO_IGNORE,
-    DEVICES_HARDCODED_METADATA,
+    DEVICE_TYPES_HARDCODED_METADATA,
+    DEVICE_TYPES_TO_IGNORE,
     SPEAKER_GROUP_FAMILY,
 )
 from .const.http import (
@@ -439,7 +439,7 @@ class AmazonEchoApi:
         for serial_number in self._final_devices:
             device_endpoint = devices_endpoints.get(serial_number, {})
             endpoint_device = self._final_devices[serial_number]
-            hardcoded_data = DEVICES_HARDCODED_METADATA.get(
+            hardcoded_data = DEVICE_TYPES_HARDCODED_METADATA.get(
                 endpoint_device.device_type, {}
             )
             endpoint_device.entity_id = (
@@ -499,7 +499,7 @@ class AmazonEchoApi:
         serial_to_device_type: dict[str, str] = {}
         for device in json_data["devices"]:
             # Remove stale, orphaned and virtual devices
-            if not device or (device.get("deviceType") in DEVICE_TYPE_TO_IGNORE):
+            if not device or (device.get("deviceType") in DEVICE_TYPES_TO_IGNORE):
                 continue
 
             account_name: str = device["accountName"]

--- a/src/aioamazondevices/const/devices.py
+++ b/src/aioamazondevices/const/devices.py
@@ -7,7 +7,7 @@ SPEAKER_GROUP_FAMILY = "WHA"
 DEVICE_TYPE_AQM = "AEZME1X38KDRA"
 DEVICE_TYPE_SPEAKER_GROUP = "A3C9PE6TNYLTCH"
 
-DEVICES_HARDCODED_METADATA: dict[str, dict[str, str]] = {
+DEVICE_TYPES_HARDCODED_METADATA: dict[str, dict[str, str]] = {
     DEVICE_TYPE_SPEAKER_GROUP: {
         "model": "Speaker Group",
         "manufacturer": "Amazon",
@@ -18,7 +18,7 @@ DEVICES_HARDCODED_METADATA: dict[str, dict[str, str]] = {
     },
 }
 
-DEVICE_TYPE_TO_IGNORE: list[str] = [
+DEVICE_TYPES_TO_IGNORE: list[str] = [
     AMAZON_DEVICE_TYPE,  # Alexa App for iOS
     "A2TF17PFR55MTB",  # Alexa App for Android
     "A1RTAM01W29CUP",  # Alexa App for PC

--- a/src/aioamazondevices/implementation/notification.py
+++ b/src/aioamazondevices/implementation/notification.py
@@ -7,7 +7,7 @@ from typing import Any
 from dateutil.parser import parse
 from dateutil.rrule import rrulestr
 
-from aioamazondevices.const.devices import DEVICE_TYPE_TO_IGNORE
+from aioamazondevices.const.devices import DEVICE_TYPES_TO_IGNORE
 from aioamazondevices.const.http import REQUEST_AGENT, URI_NOTIFICATIONS
 from aioamazondevices.const.schedules import (
     COUNTRY_GROUPS,
@@ -62,7 +62,7 @@ class AmazonNotificationHandler:
             schedule_device_type = schedule["deviceType"]
             schedule_device_serial = schedule["deviceSerialNumber"]
 
-            if schedule_device_type in DEVICE_TYPE_TO_IGNORE:
+            if schedule_device_type in DEVICE_TYPES_TO_IGNORE:
                 continue
 
             if schedule_type not in NOTIFICATIONS_SUPPORTED:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated naming conventions for internal constants related to device type identification and device metadata organization. All functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->