### PR TITLE
refactor: cleanup imports

### DIFF
--- a/src/aioamazondevices/__init__.py
+++ b/src/aioamazondevices/__init__.py
@@ -8,12 +8,9 @@ from .exceptions import (
     CannotAuthenticate,
     CannotConnect,
 )
-from .structures import AmazonDevice, AmazonMediaControls
 
 __all__ = [
-    "AmazonDevice",
     "AmazonEchoApi",
-    "AmazonMediaControls",
     "CannotAuthenticate",
     "CannotConnect",
 ]

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,7 +1,6 @@
 """Base tests for aioamazondevices."""
 
 from aioamazondevices.api import (
-    AmazonDevice,
     AmazonEchoApi,
 )
 from aioamazondevices.exceptions import (
@@ -12,7 +11,6 @@ from aioamazondevices.exceptions import (
 
 def test_objects_can_be_imported() -> None:
     """Verify objects exist."""
-    assert type(AmazonDevice)
     assert type(AmazonEchoApi)
     assert type(CannotConnect)
     assert type(CannotAuthenticate)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed `AmazonDevice` and `AmazonMediaControls` from public API exports. The package now exports only `AmazonEchoApi` and exception classes (`CannotAuthenticate`, `CannotConnect`).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->