### PR TITLE
refactor: revert pr#725

### DIFF
--- a/src/aioamazondevices/const/devices.py
+++ b/src/aioamazondevices/const/devices.py
@@ -5,8 +5,13 @@ from .http import AMAZON_DEVICE_TYPE
 SPEAKER_GROUP_FAMILY = "WHA"
 
 DEVICE_TYPE_AQM = "AEZME1X38KDRA"
+DEVICE_TYPE_SPEAKER_GROUP = "A3C9PE6TNYLTCH"
 
 DEVICE_TYPES_HARDCODED_METADATA: dict[str, dict[str, str]] = {
+    DEVICE_TYPE_SPEAKER_GROUP: {
+        "model": "Speaker Group",
+        "manufacturer": "Amazon",
+    },
     DEVICE_TYPE_AQM: {
         "model": "Air Quality Monitor",
         "manufacturer": "Amazon",


### PR DESCRIPTION
This is still needed for model identification in library (but not in integration)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Amazon Speaker Group devices. The application now recognizes and manages Speaker Groups alongside existing device types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->