### PR TITLE
fix: old devices have no 'alexaEnabledMetadata'

### DIFF
--- a/src/aioamazondevices/api.py
+++ b/src/aioamazondevices/api.py
@@ -306,9 +306,9 @@ class AmazonEchoApi:
 
         # Process Alexa Voice Enabled devices
         # Just map endpoint ID to serial number to facilitate sensor lookup
-        for endpoint in data.get("alexaVoiceDevices", {}).get("endpoints", {}):
+        for endpoint in data.get("alexaVoiceDevices", {}).get("endpoints", []):
             # save looking up sensor data on apps
-            if endpoint.get("alexaEnabledMetadata", {}).get("category") == "APP":
+            if (endpoint.get("alexaEnabledMetadata") or {}).get("category") == "APP":
                 continue
 
             if endpoint.get("serialNumber"):


### PR DESCRIPTION
Fixes #738 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Alexa Voice Enabled endpoints processing to properly handle cases where endpoint metadata is unavailable, improving reliability and preventing potential errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->