### PR TITLE
refactor: move graphql error parser to utils

### DIFF
--- a/src/aioamazondevices/api.py
+++ b/src/aioamazondevices/api.py
@@ -55,7 +55,7 @@ from .structures import (
     AmazonSequenceType,
     AmazonVolumeState,
 )
-from .utils import _LOGGER, parse_device_details
+from .utils import _LOGGER, format_graphql_error, parse_device_details
 
 
 class AmazonEchoApi:
@@ -163,7 +163,7 @@ class AmazonEchoApi:
 
         sensors_state = await self._http_wrapper.response_to_json(raw_resp, "sensors")
 
-        if await self._format_human_error(sensors_state):
+        if await format_graphql_error(sensors_state):
             # Explicit error in returned data
             return {}
 
@@ -299,7 +299,7 @@ class AmazonEchoApi:
         endpoint_data = await self._http_wrapper.response_to_json(raw_resp, "endpoint")
 
         if not (data := endpoint_data.get("data")) or not data.get("alexaVoiceDevices"):
-            await self._format_human_error(endpoint_data)
+            await format_graphql_error(endpoint_data)
             return {}
 
         devices_endpoints: dict[str, dict[str, Any]] = {}
@@ -704,21 +704,6 @@ class AmazonEchoApi:
             input_data=payload,
             json_data=True,
         )
-
-    async def _format_human_error(self, sensors_state: dict[str, Any]) -> bool:
-        """Format human readable error from malformed data."""
-        if sensors_state.get(ARRAY_WRAPPER):
-            error = sensors_state[ARRAY_WRAPPER][0].get("errors", [])
-        else:
-            error = sensors_state.get("errors", [])
-
-        if not error:
-            return False
-
-        msg = error[0].get("message", "Unknown error")
-        path = error[0].get("path", "Unknown path")
-        _LOGGER.error("Error retrieving devices state: %s for path %s", msg, path)
-        return True
 
     async def set_do_not_disturb(self, device: AmazonDevice, enable: bool) -> None:
         """Set Do Not Disturb status for a device."""

--- a/src/aioamazondevices/utils.py
+++ b/src/aioamazondevices/utils.py
@@ -5,6 +5,8 @@ import re
 from collections.abc import Collection
 from typing import Any
 
+from aioamazondevices.const.http import ARRAY_WRAPPER
+
 _LOGGER = logging.getLogger(__package__)
 
 TO_REDACT = {
@@ -119,3 +121,19 @@ def parse_device_details(model: str | None) -> tuple[str | None, str | None]:
         return parsed_model, year.strip()
 
     return model, None
+
+
+async def format_graphql_error(graphql_response: dict[str, Any]) -> bool:
+    """Format human readable e rror from malformed data."""
+    if graphql_response.get(ARRAY_WRAPPER):
+        error = graphql_response[ARRAY_WRAPPER][0].get("errors", [])
+    else:
+        error = graphql_response.get("errors", [])
+
+    if not error:
+        return False
+
+    msg = error[0].get("message", "Unknown error")
+    path = error[0].get("path", "Unknown path")
+    _LOGGER.error("Error retrieving devices state: %s for path %s", msg, path)
+    return True


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored error handling for GraphQL responses to use a centralized utility approach, improving code maintainability and consistency across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->