### PR TITLE
refactor: store media state in handler

### DIFF
--- a/library_test.py
+++ b/library_test.py
@@ -195,6 +195,15 @@ async def wait_action_complete(sleep: int = 5) -> None:
 
 async def main() -> None:
     """Run main."""
+    media_states: dict[str, AmazonMediaState] = {}
+
+    async def media_state_event_handler(
+        media_state: dict[str, AmazonMediaState],
+    ) -> None:
+        """Handle pushed media state changed events."""
+        media_states.clear()
+        media_states.update(media_state)
+
     _, args = await get_arguments()
 
     login_data_stored = await read_from_file(args.login_data_file)
@@ -284,20 +293,17 @@ async def main() -> None:
     if not args.test:
         print("!!! No testing requested, exiting !!!")
     else:
-        await tests(args, api, devices)
+        await tests(args, api, devices, media_states)
 
     print("Closing session")
     await client_session.close()
 
 
-async def media_state_event_handler(media_state: dict[str, AmazonMediaState]) -> None:
-    """Handle pushed media state changed events."""
-    global media_states  # noqa: PLW0603
-    media_states = media_state
-
-
 async def tests(
-    args: Namespace, api: AmazonEchoApi, devices: dict[str, AmazonDevice]
+    args: Namespace,
+    api: AmazonEchoApi,
+    devices: dict[str, AmazonDevice],
+    media_states: dict[str, AmazonMediaState],
 ) -> None:
     """Run tests."""
     print("*" * 20)

--- a/library_test.py
+++ b/library_test.py
@@ -35,7 +35,6 @@ SAVE_PATH_DATE = datetime.now(UTC).strftime("%Y-%m-%d-%H-%M-%S")
 HTML_EXTENSION = ".html"
 BIN_EXTENSION = ".bin"
 RAW_EXTENSION = ".raw"
-media_states: dict[str, AmazonMediaState] = {}
 
 
 async def get_arguments() -> tuple[ArgumentParser, Namespace]:

--- a/library_test.py
+++ b/library_test.py
@@ -26,6 +26,7 @@ from aioamazondevices.exceptions import (
 from aioamazondevices.structures import (
     AmazonDevice,
     AmazonMediaControls,
+    AmazonMediaState,
     AmazonMusicProvider,
 )
 
@@ -34,6 +35,7 @@ SAVE_PATH_DATE = datetime.now(UTC).strftime("%Y-%m-%d-%H-%M-%S")
 HTML_EXTENSION = ".html"
 BIN_EXTENSION = ".bin"
 RAW_EXTENSION = ".raw"
+media_states: dict[str, AmazonMediaState] = {}
 
 
 async def get_arguments() -> tuple[ArgumentParser, Namespace]:
@@ -211,6 +213,9 @@ async def main() -> None:
         save_to_file=save_to_file,
     )
 
+    api.on_media_state_event.append(media_state_event_handler)
+    api.on_media_state_event.freeze()
+
     try:
         try:
             if login_data_stored:
@@ -283,6 +288,12 @@ async def main() -> None:
 
     print("Closing session")
     await client_session.close()
+
+
+async def media_state_event_handler(media_state: dict[str, AmazonMediaState]) -> None:
+    """Handle pushed media state changed events."""
+    global media_states  # noqa: PLW0603
+    media_states = media_state
 
 
 async def tests(
@@ -423,7 +434,9 @@ async def tests(
         await api.send_media_command(device_single, AmazonMediaControls.Next)
         await wait_action_complete(15)
 
-        media_states = await api.sync_media_state()
+        await api.sync_media_state()
+        await wait_action_complete()
+
         for device in devices.values():
             media_state = media_states.get(device.serial_number)
             if media_state:

--- a/src/aioamazondevices/api.py
+++ b/src/aioamazondevices/api.py
@@ -330,8 +330,12 @@ class AmazonEchoApi:
 
     async def _emit_media_state_event(self) -> None:
         """Emit media state data to subscribers."""
-        await self.on_media_state_event.send(await self._media_handler.media_states)
+        if self.on_media_state_event.frozen:
+            await self.on_media_state_event.send(await self._media_handler.media_states)
 
     async def _emit_volume_state_event(self) -> None:
         """Emit volume event to subscribers."""
-        await self.on_volume_state_event.send(await self._media_handler.device_volumes)
+        if self.on_volume_state_event.frozen:
+            await self.on_volume_state_event.send(
+                await self._media_handler.device_volumes
+            )

--- a/src/aioamazondevices/api.py
+++ b/src/aioamazondevices/api.py
@@ -106,10 +106,7 @@ class AmazonEchoApi:
         self._last_daily_refresh: datetime = initial_time
         self._last_endpoint_refresh: datetime = initial_time
 
-        self._media_states: dict[str, AmazonMediaState] = {}
         self.on_media_state_event = Signal[dict[str, AmazonMediaState]](self)
-
-        self._volume_states: dict[str, AmazonVolumeState] = {}
         self.on_volume_state_event = Signal[dict[str, AmazonVolumeState]](self)
 
     @property
@@ -320,24 +317,21 @@ class AmazonEchoApi:
         """Set Do Not Disturb status for a device."""
         await self._dnd_handler.set_do_not_disturb(device, enable)
 
-    async def sync_media_state(self) -> dict[str, AmazonMediaState]:
+    async def sync_media_state(self) -> None:
         """Sync media state.
 
         This will be called at startup to sync media state of all devices
         and can be called later to refresh media state.
         """
-        self._volume_states = await self._media_handler.get_device_volumes()
+        await self._media_handler.sync_device_volumes()
         await self._emit_volume_state_event()
-        self._media_states = await self._media_handler.sync_media_state(
-            self._device_handler.devices
-        )
+        await self._media_handler.sync_media_state(self._device_handler.devices)
         await self._emit_media_state_event()
-        return self._media_states
 
     async def _emit_media_state_event(self) -> None:
         """Emit media state data to subscribers."""
-        await self.on_media_state_event.send(self._media_states)
+        await self.on_media_state_event.send(self._media_handler.media_states)
 
     async def _emit_volume_state_event(self) -> None:
         """Emit volume event to subscribers."""
-        await self.on_volume_state_event.send(self._volume_states)
+        await self.on_volume_state_event.send(self._media_handler.device_volumes)

--- a/src/aioamazondevices/api.py
+++ b/src/aioamazondevices/api.py
@@ -330,8 +330,8 @@ class AmazonEchoApi:
 
     async def _emit_media_state_event(self) -> None:
         """Emit media state data to subscribers."""
-        await self.on_media_state_event.send(self._media_handler.media_states)
+        await self.on_media_state_event.send(await self._media_handler.media_states)
 
     async def _emit_volume_state_event(self) -> None:
         """Emit volume event to subscribers."""
-        await self.on_volume_state_event.send(self._media_handler.device_volumes)
+        await self.on_volume_state_event.send(await self._media_handler.device_volumes)

--- a/src/aioamazondevices/implementation/media.py
+++ b/src/aioamazondevices/implementation/media.py
@@ -104,6 +104,7 @@ class AmazonMediaHandler:
         # the endpoint needs a device type / serial but returns all sessions
         media_sessions = await self._get_media_states(next(iter(devices.values())))
         if not media_sessions:
+            self._media_states = {}
             return
 
         for device in devices.values():

--- a/src/aioamazondevices/implementation/media.py
+++ b/src/aioamazondevices/implementation/media.py
@@ -33,7 +33,7 @@ class AmazonMediaHandler:
         """Initialize AmazonMediaHandler class."""
         self._session_state_data = session_state_data
         self._http_wrapper = http_wrapper
-        self._music_providers: dict[str, AmazonMusicProvider]
+        self._music_providers: dict[str, AmazonMusicProvider] = {}
         self._device_volumes: dict[str, AmazonVolumeState] = {}
         self._media_states: dict[str, AmazonMediaState] = {}
 
@@ -42,7 +42,7 @@ class AmazonMediaHandler:
         """Return music providers."""
         if not self._music_providers:
             await self.update_music_providers()
-        return self._music_providers or {}
+        return self._music_providers
 
     @property
     async def device_volumes(self) -> dict[str, AmazonVolumeState]:
@@ -54,7 +54,7 @@ class AmazonMediaHandler:
     @property
     async def media_states(self) -> dict[str, AmazonMediaState]:
         """Return media states."""
-        return self._media_states or {}
+        return self._media_states
 
     async def sync_device_volumes(self) -> None:
         """Sync all device volumes."""

--- a/src/aioamazondevices/implementation/media.py
+++ b/src/aioamazondevices/implementation/media.py
@@ -100,7 +100,7 @@ class AmazonMediaHandler:
 
     async def sync_media_state(self, devices: dict[str, AmazonDevice]) -> None:
         """Sync media states."""
-        _media_states = {}
+        media_states = {}
         # the endpoint needs a device type / serial but returns all sessions
         media_sessions = await self._get_media_states(next(iter(devices.values())))
         if not media_sessions:
@@ -119,7 +119,7 @@ class AmazonMediaHandler:
             str_media_progress = now_playing.get("progress", {}).get("mediaProgress")
             transport = now_playing.get("transport", {})
             provider = now_playing.get("provider", {})
-            _media_states[serial_number] = AmazonMediaState(
+            media_states[serial_number] = AmazonMediaState(
                 player_state=now_playing.get("playerState"),
                 now_playing_url=now_playing.get("mainArt", {}).get("largeUrl"),
                 now_playing_title=now_playing.get("infoText", {}).get("title"),
@@ -147,7 +147,7 @@ class AmazonMediaHandler:
                 media_provider_url=provider.get("providerLogo", {}).get("url"),
             )
 
-        self._media_states = _media_states
+        self._media_states = media_states
 
     async def update_music_providers(self) -> None:
         """Update availables music providers."""

--- a/src/aioamazondevices/implementation/media.py
+++ b/src/aioamazondevices/implementation/media.py
@@ -34,16 +34,30 @@ class AmazonMediaHandler:
         self._session_state_data = session_state_data
         self._http_wrapper = http_wrapper
         self._music_providers: dict[str, AmazonMusicProvider]
+        self._device_volumes: dict[str, AmazonVolumeState] = {}
+        self._media_states: dict[str, AmazonMediaState] = {}
 
     @property
     async def music_providers(self) -> dict[str, AmazonMusicProvider]:
         """Return music providers."""
         if not self._music_providers:
             await self.update_music_providers()
-        return self._music_providers
+        return self._music_providers or {}
 
-    async def get_device_volumes(self) -> dict[str, AmazonVolumeState]:
-        """Get all device volumes."""
+    @property
+    async def device_volumes(self) -> dict[str, AmazonVolumeState]:
+        """Return device volumes."""
+        if not self._device_volumes:
+            await self.sync_device_volumes()
+        return self._device_volumes
+
+    @property
+    async def media_states(self) -> dict[str, AmazonMediaState]:
+        """Return media states."""
+        return self._media_states or {}
+
+    async def sync_device_volumes(self) -> None:
+        """Sync all device volumes."""
         _, raw_resp = await self._http_wrapper.session_request(
             method=HTTPMethod.GET,
             url=f"https://alexa.amazon.{self._session_state_data.domain}{URI_DEVICE_VOLUMES}",
@@ -59,7 +73,7 @@ class AmazonMediaHandler:
                 device_volume_data["speakerVolume"], device_volume_data["speakerMuted"]
             )
 
-        return _volumes
+        self._device_volumes = _volumes
 
     async def _get_media_states(self, device: AmazonDevice) -> dict[str, Any]:
         """Get media state for devices.
@@ -84,15 +98,13 @@ class AmazonMediaHandler:
 
         return media_sessions
 
-    async def sync_media_state(
-        self, devices: dict[str, AmazonDevice]
-    ) -> dict[str, AmazonMediaState]:
-        """Return all media state."""
-        media_states = {}
+    async def sync_media_state(self, devices: dict[str, AmazonDevice]) -> None:
+        """Sync media states."""
+        _media_states = {}
         # the endpoint needs a device type / serial but returns all sessions
         media_sessions = await self._get_media_states(next(iter(devices.values())))
         if not media_sessions:
-            return {}
+            return
 
         for device in devices.values():
             if not device.media_player_supported:
@@ -106,7 +118,7 @@ class AmazonMediaHandler:
             str_media_progress = now_playing.get("progress", {}).get("mediaProgress")
             transport = now_playing.get("transport", {})
             provider = now_playing.get("provider", {})
-            media_states[serial_number] = AmazonMediaState(
+            _media_states[serial_number] = AmazonMediaState(
                 player_state=now_playing.get("playerState"),
                 now_playing_url=now_playing.get("mainArt", {}).get("largeUrl"),
                 now_playing_title=now_playing.get("infoText", {}).get("title"),
@@ -134,7 +146,7 @@ class AmazonMediaHandler:
                 media_provider_url=provider.get("providerLogo", {}).get("url"),
             )
 
-        return media_states
+        self._media_states = _media_states
 
     async def update_music_providers(self) -> None:
         """Update availables music providers."""

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "aioamazondevices"
-version = "13.4.1"
+version = "13.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
move volume and media state cache to media handler.
this makes sync easier (will aid https://github.com/chemelli74/aioamazondevices/pull/783)
removed redundant return values and generally aligns things based on HA media player implementation and testing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Media-state and device-volume handling now uses internal cached stores and property-style access.
  * Synchronization no longer returns media state directly; updates are pushed via events and emitted only when stable.

* **Tests**
  * Test flow updated to consume pushed media-state events and wait for completion before asserting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->