### PR TITLE
refactor: move http2 restart into library

### DIFF
--- a/src/aioamazondevices/api.py
+++ b/src/aioamazondevices/api.py
@@ -188,7 +188,9 @@ class AmazonEchoApi:
         return self._device_handler.devices
 
     async def start_http2_processing(
-        self, httpx_client: httpx.AsyncClient
+        self,
+        httpx_client: httpx.AsyncClient,
+        on_reauth_required: Callable[[], Coroutine[Any, Any, None]] | None = None,
     ) -> asyncio.Task[None]:
         """Start HTTP2 background processing.
 
@@ -205,6 +207,7 @@ class AmazonEchoApi:
                 http_wrapper=self._http_wrapper,
                 session_state_data=self._session_state_data,
                 httpx_client=httpx_client,
+                on_reauth_required=on_reauth_required,
             )
             self._http2_client.on_push_event.append(self._http2_push_event_handler)
             self._http2_client.on_push_event.freeze()

--- a/src/aioamazondevices/implementation/http2.py
+++ b/src/aioamazondevices/implementation/http2.py
@@ -216,6 +216,7 @@ class AmazonHTTP2Client:
                     self._run_task = None
 
     async def _run_tasks(self) -> None:
+        """Run stream and ping tasks until stopped or an unhandled exception occurs."""
         self._reconnect_attempt = 0
         while not self._stop_event.is_set():
             # exponential backoff with a max of 10 minutes between reconnect attempts

--- a/src/aioamazondevices/implementation/http2.py
+++ b/src/aioamazondevices/implementation/http2.py
@@ -182,6 +182,8 @@ class AmazonHTTP2Client:
         self._connected_event = asyncio.Event()
         self._process_lock = asyncio.Lock()
 
+        self._reconnect_attempt: int = 0
+
     async def start_processing(self) -> asyncio.Task[None]:
         """Start background processing. Returns the task to the caller."""
         async with self._process_lock:
@@ -214,7 +216,12 @@ class AmazonHTTP2Client:
                     self._run_task = None
 
     async def _run_tasks(self) -> None:
+        self._reconnect_attempt = 0
         while not self._stop_event.is_set():
+            # exponential backoff with a max of 10 minutes between reconnect attempts
+            # the backoff resets after a successful ping
+            delay = min(HTTP2_RECONNECT_DELAY * (2**self._reconnect_attempt), 600)
+
             reauth_required = False
             restart_required = False
             try:
@@ -234,7 +241,7 @@ class AmazonHTTP2Client:
                 for connect_exc in connect_exc_group.exceptions:
                     _LOGGER.warning(
                         "HTTP2 connection failure, reconnecting in %s seconds",
-                        HTTP2_RECONNECT_DELAY,
+                        delay,
                         exc_info=(
                             type(connect_exc),
                             connect_exc,
@@ -247,7 +254,7 @@ class AmazonHTTP2Client:
                 for e in eg.exceptions:
                     _LOGGER.error(
                         "Unexpected HTTP2 failure, reconnecting in %s seconds",
-                        HTTP2_RECONNECT_DELAY,
+                        delay,
                         exc_info=(type(e), e, e.__traceback__),
                     )
                 restart_required = True
@@ -257,7 +264,8 @@ class AmazonHTTP2Client:
                     await self._on_reauth_required()
                 break
             if restart_required:
-                await asyncio.sleep(HTTP2_RECONNECT_DELAY)
+                await asyncio.sleep(delay)
+                self._reconnect_attempt += 1
 
     async def _register_device_capabilities(self) -> None:
         """Register device capabilities."""
@@ -485,6 +493,9 @@ class AmazonHTTP2Client:
             raise CannotAuthenticate(
                 f"Ping returned {response.status_code}; check credentials and region"
             )
+
+        # Reset backoff after healthy ping
+        self._reconnect_attempt = 0
 
     def _get_bearer_token(self) -> str:
         """Return the current access token."""

--- a/src/aioamazondevices/implementation/http2.py
+++ b/src/aioamazondevices/implementation/http2.py
@@ -1,6 +1,7 @@
 """HTTP2 Support for Amazon devices."""
 
 import asyncio
+from collections.abc import Callable, Coroutine
 from http import HTTPMethod, HTTPStatus
 from typing import Any
 
@@ -165,6 +166,7 @@ class AmazonHTTP2Client:
         http_wrapper: AmazonHttpWrapper,
         session_state_data: AmazonSessionStateData,
         httpx_client: httpx.AsyncClient,
+        on_reauth_required: Callable[[], Coroutine[Any, Any, None]] | None = None,
     ) -> None:
         """Initialize Amazon HTTP2 client class."""
         self._http_wrapper = http_wrapper
@@ -172,6 +174,8 @@ class AmazonHTTP2Client:
 
         self._http2_client = httpx_client
         self.on_push_event: Signal[str, dict[str, Any]] = Signal(self)
+
+        self._on_reauth_required = on_reauth_required
 
         self._run_task: asyncio.Task[None] | None = None
         self._stop_event = asyncio.Event()
@@ -210,17 +214,49 @@ class AmazonHTTP2Client:
                     self._run_task = None
 
     async def _run_tasks(self) -> None:
-        """Run stream and ping tasks until stopped or an unhandled exception occurs."""
         while not self._stop_event.is_set():
+            reauth_required = False
+            restart_required = False
             try:
                 async with asyncio.TaskGroup() as tg:
                     tg.create_task(self._get_avs_directives(), name="avs-stream")
                     tg.create_task(self._ping_loop(), name="avs-ping")
-            except* httpx.TimeoutException:
-                _LOGGER.warning(
-                    "HTTP2: Ping timeout, reconnecting in %s seconds",
-                    HTTP2_RECONNECT_DELAY,
-                )
+
+            except* CannotAuthenticate as auth_exc_group:
+                for auth_exc in auth_exc_group.exceptions:
+                    _LOGGER.error(
+                        "HTTP2 auth failure",
+                        exc_info=(type(auth_exc), auth_exc, auth_exc.__traceback__),
+                    )
+                reauth_required = True
+
+            except* (CannotConnect, httpx.TimeoutException) as connect_exc_group:
+                for connect_exc in connect_exc_group.exceptions:
+                    _LOGGER.warning(
+                        "HTTP2 connection failure, reconnecting in %s seconds",
+                        HTTP2_RECONNECT_DELAY,
+                        exc_info=(
+                            type(connect_exc),
+                            connect_exc,
+                            connect_exc.__traceback__,
+                        ),
+                    )
+                restart_required = True
+
+            except* Exception as eg:  # noqa: BLE001
+                for e in eg.exceptions:
+                    _LOGGER.error(
+                        "Unexpected HTTP2 failure, reconnecting in %s seconds",
+                        HTTP2_RECONNECT_DELAY,
+                        exc_info=(type(e), e, e.__traceback__),
+                    )
+                restart_required = True
+
+            if reauth_required:
+                if self._on_reauth_required:
+                    await self._on_reauth_required()
+                break
+            if restart_required:
                 await asyncio.sleep(HTTP2_RECONNECT_DELAY)
 
     async def _register_device_capabilities(self) -> None:

--- a/src/aioamazondevices/implementation/http2.py
+++ b/src/aioamazondevices/implementation/http2.py
@@ -232,31 +232,18 @@ class AmazonHTTP2Client:
 
             except* CannotAuthenticate as auth_exc_group:
                 for auth_exc in auth_exc_group.exceptions:
-                    _LOGGER.error(
+                    _LOGGER.warning(
                         "HTTP2 auth failure",
                         exc_info=(type(auth_exc), auth_exc, auth_exc.__traceback__),
                     )
                 reauth_required = True
 
-            except* (CannotConnect, httpx.TimeoutException) as connect_exc_group:
-                for connect_exc in connect_exc_group.exceptions:
+            except* Exception as exc_group:  # noqa: BLE001
+                for exc in exc_group.exceptions:
                     _LOGGER.warning(
-                        "HTTP2 connection failure, reconnecting in %s seconds",
+                        "HTTP2 failure, reconnecting in %s seconds",
                         delay,
-                        exc_info=(
-                            type(connect_exc),
-                            connect_exc,
-                            connect_exc.__traceback__,
-                        ),
-                    )
-                restart_required = True
-
-            except* Exception as eg:  # noqa: BLE001
-                for e in eg.exceptions:
-                    _LOGGER.error(
-                        "Unexpected HTTP2 failure, reconnecting in %s seconds",
-                        delay,
-                        exc_info=(type(e), e, e.__traceback__),
+                        exc_info=(type(exc), exc, exc.__traceback__),
                     )
                 restart_required = True
 


### PR DESCRIPTION
This moves http2 restart logic from integration back to library.
It introduces a callback so we can get HA to start reauth flow if we get auth failures in http2 stream

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional async re‑authentication callback to automatically trigger re‑auth when needed, improving connection resilience.

* **Bug Fixes**
  * Clearer separation of authentication failures vs network errors with targeted handling.
  * Improved reconnection logic: concurrent streams, exponential backoff with capped delays, and retry state reset after successful ping.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chemelli74/aioamazondevices/pull/832?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->