### PR TITLE
feat: add default_device setter

### DIFF
--- a/src/aioamazondevices/api.py
+++ b/src/aioamazondevices/api.py
@@ -143,6 +143,24 @@ class AmazonEchoApi:
         return self._sequence_handler.routines
 
     @property
+    def default_device(self) -> AmazonDevice:
+        """Return default device."""
+        if self._default_device:
+            return self._default_device
+
+        # Get first online device as default if no default device has been set yet
+        for device in self._device_handler.devices.values():
+            if device.online:
+                return device
+
+        raise ValueError("No online devices found")
+
+    @default_device.setter
+    def default_device(self, device: AmazonDevice) -> None:
+        """Set default device."""
+        self._default_device = device
+
+    @property
     async def music_providers(self) -> dict[str, AmazonMusicProvider]:
         """Return music providers."""
         return await self._media_handler.music_providers
@@ -344,7 +362,7 @@ class AmazonEchoApi:
         # Routines are not device specific
         # but a device is needed to call them anyway.
         await self._call_alexa_command_per_cluster_member(
-            self._device_handler.default_device,
+            self._default_device,
             AmazonSequenceType.Routines,
             routine_name,
         )

--- a/src/aioamazondevices/api.py
+++ b/src/aioamazondevices/api.py
@@ -61,6 +61,8 @@ class AmazonEchoApi:
         """Initialize the scanner."""
         _LOGGER.debug("Initialize library v%s", __version__)
 
+        self._default_device: AmazonDevice | None = None
+
         # Check if there is a previous login, otherwise use default (US)
         site = login_data.get("site", DEFAULT_SITE) if login_data else DEFAULT_SITE
         _LOGGER.debug("Using site: %s", site)
@@ -362,7 +364,7 @@ class AmazonEchoApi:
         # Routines are not device specific
         # but a device is needed to call them anyway.
         await self._call_alexa_command_per_cluster_member(
-            self._default_device,
+            self.default_device,
             AmazonSequenceType.Routines,
             routine_name,
         )

--- a/src/aioamazondevices/implementation/device.py
+++ b/src/aioamazondevices/implementation/device.py
@@ -35,14 +35,6 @@ class AmazonDeviceHandler:
         return self._final_devices
 
     @property
-    def default_device(self) -> AmazonDevice:
-        """Return the default device."""
-        for device in self._final_devices.values():
-            if device.online:
-                return device
-        raise ValueError("No online devices found")
-
-    @property
     def endpoints(self) -> dict[str, str]:
         """Return the endpoints mapping."""
         return self._endpoints


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `default_device` property to the API for managing device selection. When not explicitly set, it automatically selects the first available online device.

* **API Changes**
  * Device handler now exposes an `endpoints` property for accessing device mappings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chemelli74/aioamazondevices/pull/835?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->