### PR TITLE
fix!: handle recordType history records

### DIFF
--- a/src/aioamazondevices/implementation/history.py
+++ b/src/aioamazondevices/implementation/history.py
@@ -77,15 +77,15 @@ class AmazonHistoryHandler:
         records: dict[str, AmazonVocalRecord] = {}
         for record in history_json["alexaHistoryRecords"]:
             _LOGGER.debug("Processing vocal history record: %s", record)
-            utterance_type = record["utteranceType"]
+            utterance_type = record.get("utteranceType")
             if (
                 utterance_type
-                in [
+                in (
                     "ASR_TIMEOUT",
                     "DEVICE_ARBITRATION",
                     "NO_EXPRESSED_INTENT",
                     "WAKE_WORD_ONLY",
-                ]
+                )
                 # InvokeRoutineIntent, AddToListIntent are not linked to a device
                 or record["deviceInfo"] is None
             ):
@@ -95,10 +95,11 @@ class AmazonHistoryHandler:
             timestamp = record["timestamp"]
             new_record = AmazonVocalRecord(
                 timestamp=timestamp,
+                record_type=record.get("recordType", "UNKNOWN"),
                 utterance_type=utterance_type,
-                intent=record["intent"],
-                title=record["title"],
-                sub_title=record["subTitle"],
+                intent=record.get("intent"),
+                title=record.get("title"),
+                sub_title=record.get("subTitle"),
             )
             # Store only the latest record per serial number
             if serial not in records or timestamp > records[serial].timestamp:

--- a/src/aioamazondevices/implementation/history.py
+++ b/src/aioamazondevices/implementation/history.py
@@ -100,9 +100,7 @@ class AmazonHistoryHandler:
             timestamp = record["timestamp"]
             new_record = AmazonVocalRecord(
                 timestamp=timestamp,
-                history_type=record.get("utteranceType")
-                or record.get("recordType")
-                or "Unknown",
+                history_type=utterance_type or record.get("recordType") or "Unknown",
                 intent=record.get("intent") or "Unknown",
                 title=record["title"],
                 sub_title=record["subTitle"],

--- a/src/aioamazondevices/implementation/history.py
+++ b/src/aioamazondevices/implementation/history.py
@@ -100,8 +100,10 @@ class AmazonHistoryHandler:
             timestamp = record["timestamp"]
             new_record = AmazonVocalRecord(
                 timestamp=timestamp,
-                voice_type=record.get("utteranceType") or record.get("recordType"),
-                intent=record.get("intent") or record.get("type") or "",
+                history_type=record.get("utteranceType")
+                or record.get("recordType")
+                or "Unknown",
+                intent=record.get("intent") or "Unknown",
                 title=record["title"],
                 sub_title=record["subTitle"],
             )

--- a/src/aioamazondevices/implementation/history.py
+++ b/src/aioamazondevices/implementation/history.py
@@ -87,7 +87,7 @@ class AmazonHistoryHandler:
                     "WAKE_WORD_ONLY",
                 ]
                 # InvokeRoutineIntent, AddToListIntent are not linked to a device
-                or record["deviceInfo"] is None
+                or record.get("deviceInfo") is None
             ):
                 continue
 

--- a/src/aioamazondevices/implementation/history.py
+++ b/src/aioamazondevices/implementation/history.py
@@ -93,7 +93,7 @@ class AmazonHistoryHandler:
                 continue
 
             if isinstance(device_info, list):
-                device_info = device_info[0]
+                device_info = device_info[0] if device_info else None
             if not isinstance(device_info, dict):
                 continue
             serial = device_info["deviceSerialNumber"]
@@ -102,7 +102,7 @@ class AmazonHistoryHandler:
                 timestamp=timestamp,
                 record_type=record.get("recordType", "UNKNOWN"),
                 voice_type=record.get("utteranceType") or record.get("recordType"),
-                intent=record.get("intent") or record.get("type"),
+                intent=record.get("intent") or record.get("type") or "",
                 title=record["title"],
                 sub_title=record["subTitle"],
             )

--- a/src/aioamazondevices/implementation/history.py
+++ b/src/aioamazondevices/implementation/history.py
@@ -80,12 +80,12 @@ class AmazonHistoryHandler:
             utterance_type = record.get("utteranceType")
             if (
                 utterance_type
-                in (
+                in [
                     "ASR_TIMEOUT",
                     "DEVICE_ARBITRATION",
                     "NO_EXPRESSED_INTENT",
                     "WAKE_WORD_ONLY",
-                )
+                ]
                 # InvokeRoutineIntent, AddToListIntent are not linked to a device
                 or record["deviceInfo"] is None
             ):

--- a/src/aioamazondevices/implementation/history.py
+++ b/src/aioamazondevices/implementation/history.py
@@ -96,10 +96,10 @@ class AmazonHistoryHandler:
             new_record = AmazonVocalRecord(
                 timestamp=timestamp,
                 record_type=record.get("recordType", "UNKNOWN"),
-                utterance_type=utterance_type,
-                intent=record.get("intent"),
-                title=record.get("title"),
-                sub_title=record.get("subTitle"),
+                voice_type=record.get("utteranceType") or record.get("recordType"),
+                intent=record.get("intent") or record.get("type"),
+                title=record["title"],
+                sub_title=record["subTitle"],
             )
             # Store only the latest record per serial number
             if serial not in records or timestamp > records[serial].timestamp:

--- a/src/aioamazondevices/implementation/history.py
+++ b/src/aioamazondevices/implementation/history.py
@@ -78,6 +78,7 @@ class AmazonHistoryHandler:
         for record in history_json["alexaHistoryRecords"]:
             _LOGGER.debug("Processing vocal history record: %s", record)
             utterance_type = record.get("utteranceType")
+            device_info = record.get("deviceInfo")
             if (
                 utterance_type
                 in [
@@ -87,11 +88,15 @@ class AmazonHistoryHandler:
                     "WAKE_WORD_ONLY",
                 ]
                 # InvokeRoutineIntent, AddToListIntent are not linked to a device
-                or record.get("deviceInfo") is None
+                or device_info is None
             ):
                 continue
 
-            serial = record["deviceInfo"]["deviceSerialNumber"]
+            if isinstance(device_info, list):
+                device_info = device_info[0]
+            if not isinstance(device_info, dict):
+                continue
+            serial = device_info["deviceSerialNumber"]
             timestamp = record["timestamp"]
             new_record = AmazonVocalRecord(
                 timestamp=timestamp,

--- a/src/aioamazondevices/implementation/history.py
+++ b/src/aioamazondevices/implementation/history.py
@@ -100,7 +100,6 @@ class AmazonHistoryHandler:
             timestamp = record["timestamp"]
             new_record = AmazonVocalRecord(
                 timestamp=timestamp,
-                record_type=record.get("recordType", "UNKNOWN"),
                 voice_type=record.get("utteranceType") or record.get("recordType"),
                 intent=record.get("intent") or record.get("type") or "",
                 title=record["title"],

--- a/src/aioamazondevices/structures.py
+++ b/src/aioamazondevices/structures.py
@@ -166,10 +166,11 @@ class AmazonVocalRecord:
     """Amazon vocal record."""
 
     timestamp: int
-    utterance_type: str
-    intent: str
+    record_type: str
+    utterance_type: str | None
+    intent: str | None
     title: str
-    sub_title: str
+    sub_title: str | None
 
 
 class AmazonListType(StrEnum):

--- a/src/aioamazondevices/structures.py
+++ b/src/aioamazondevices/structures.py
@@ -166,7 +166,6 @@ class AmazonVocalRecord:
     """Amazon vocal record."""
 
     timestamp: int
-    record_type: str
     voice_type: str
     intent: str
     title: str

--- a/src/aioamazondevices/structures.py
+++ b/src/aioamazondevices/structures.py
@@ -167,10 +167,10 @@ class AmazonVocalRecord:
 
     timestamp: int
     record_type: str
-    utterance_type: str | None
-    intent: str | None
-    title: str | None
-    sub_title: str | None
+    voice_type: str
+    intent: str
+    title: str
+    sub_title: str
 
 
 class AmazonListType(StrEnum):

--- a/src/aioamazondevices/structures.py
+++ b/src/aioamazondevices/structures.py
@@ -169,7 +169,7 @@ class AmazonVocalRecord:
     record_type: str
     utterance_type: str | None
     intent: str | None
-    title: str
+    title: str | None
     sub_title: str | None
 
 

--- a/src/aioamazondevices/structures.py
+++ b/src/aioamazondevices/structures.py
@@ -166,7 +166,7 @@ class AmazonVocalRecord:
     """Amazon vocal record."""
 
     timestamp: int
-    voice_type: str
+    history_type: str
     intent: str
     title: str
     sub_title: str


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Vocal history parsing is more resilient: malformed or missing fields (including absent device info) are safely skipped to prevent errors and preserve per-device behavior.

* **New Features**
  * Records now expose a single consolidated record-type field and use safer fallbacks for intent, timestamp, title and subtitle, improving accuracy and stability of recent voice-interaction history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->