### PR TITLE
refactor: change none returns to exceptions

### DIFF
--- a/src/aioamazondevices/implementation/http2.py
+++ b/src/aioamazondevices/implementation/http2.py
@@ -339,7 +339,7 @@ class AmazonHTTP2Client:
             REFRESH_ACCESS_TOKEN
         )
         if not refresh_successful:
-            raise CannotRetrieveData("Failed to refresh access token")
+            _LOGGER.warning("Failed to refresh access token")
 
     async def _stream_and_process(self) -> None:
         """Open stream and process incoming directives."""

--- a/src/aioamazondevices/implementation/http2.py
+++ b/src/aioamazondevices/implementation/http2.py
@@ -302,9 +302,6 @@ class AmazonHTTP2Client:
         boundary = http2_parse_boundary_delimiter(
             response.headers.get("content-type", "")
         )
-        if boundary is None:
-            _LOGGER.warning("Missing multipart boundary in SynchronizeState response")
-            return
 
         parser = AvsDirectiveStreamParser(boundary)
         parts = parser.feed(response.content)
@@ -388,9 +385,6 @@ class AmazonHTTP2Client:
             boundary = http2_parse_boundary_delimiter(
                 response.headers.get("content-type", "")
             )
-            if boundary is None:
-                _LOGGER.warning("Missing multipart boundary")
-                return
 
             # Stream confirmed open — allow the ping loop to start firing.
             self._connected_event.set()
@@ -409,7 +403,7 @@ class AmazonHTTP2Client:
                 return
             except BufferError:
                 _LOGGER.error("Buffer exceeded maximum size, forcing reconnect")
-                return
+                raise CannotRetrieveData("Buffer exceeded maximum size") from None
             finally:
                 _LOGGER.debug("AVS Directives stream closed")
                 self._connected_event.clear()

--- a/src/aioamazondevices/implementation/http2.py
+++ b/src/aioamazondevices/implementation/http2.py
@@ -18,7 +18,6 @@ from aioamazondevices.const.http import (
 )
 from aioamazondevices.exceptions import (
     CannotAuthenticate,
-    CannotConnect,
     CannotRetrieveData,
     UpdatedAVSSite,
 )
@@ -327,29 +326,20 @@ class AmazonHTTP2Client:
         while not self._stop_event.is_set():
             self._connected_event.clear()
 
-            if not (await self._refresh_token()):
-                await asyncio.sleep(HTTP2_RECONNECT_DELAY)
-                continue
-
+            await self._refresh_token()
             await self._stream_and_process()
 
             if not self._stop_event.is_set():
                 _LOGGER.debug("Reconnecting in %s seconds", HTTP2_RECONNECT_DELAY)
                 await asyncio.sleep(HTTP2_RECONNECT_DELAY)
 
-    async def _refresh_token(self) -> bool:
+    async def _refresh_token(self) -> None:
         """Refresh the access token."""
-        try:
-            refresh_successful, _ = await self._http_wrapper.refresh_data(
-                REFRESH_ACCESS_TOKEN
-            )
-            if not refresh_successful:
-                _LOGGER.warning("Failed to refresh access token")
-                return False
-        except (CannotConnect, CannotRetrieveData) as exc:
-            _LOGGER.warning("Failed to refresh access token: %s", exc)
-            return False
-        return True
+        refresh_successful, _ = await self._http_wrapper.refresh_data(
+            REFRESH_ACCESS_TOKEN
+        )
+        if not refresh_successful:
+            raise CannotRetrieveData("Failed to refresh access token")
 
     async def _stream_and_process(self) -> None:
         """Open stream and process incoming directives."""

--- a/src/aioamazondevices/utils.py
+++ b/src/aioamazondevices/utils.py
@@ -11,6 +11,7 @@ from typing import Any
 import orjson
 
 from aioamazondevices.const.http import ARRAY_WRAPPER
+from aioamazondevices.exceptions import CannotRetrieveData
 from aioamazondevices.structures import AmazonDevice
 
 _LOGGER = logging.getLogger(__package__)
@@ -77,7 +78,7 @@ def http2_extract_json_from_part(part: bytes) -> dict[str, Any] | None:
         return parsed
 
 
-def http2_parse_boundary_delimiter(content_type: str) -> bytes | None:
+def http2_parse_boundary_delimiter(content_type: str) -> bytes:
     """Extract the boundary delimiter from a Content-Type header value.
 
     Returns the full delimiter bytes (with '--' prefix) ready for use
@@ -86,7 +87,7 @@ def http2_parse_boundary_delimiter(content_type: str) -> bytes | None:
     msg = EmailMessage()
     msg["Content-Type"] = content_type
     if not (boundary := msg.get_boundary()):
-        return None
+        raise CannotRetrieveData("Missing multipart boundary")
     return f"--{boundary}".encode()
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Missing or invalid multipart response boundaries are now reported as explicit errors instead of being ignored.
  * Buffer overflow conditions in directive streams now raise errors that propagate to trigger proper reconnect/recovery.
  * Token refresh failures no longer get silently swallowed, ensuring upstream retry/reconnect logic can run reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->