### PR TITLE
fix: ensure todo domain updates when changed

### DIFF
--- a/src/aioamazondevices/implementation/todo.py
+++ b/src/aioamazondevices/implementation/todo.py
@@ -27,8 +27,6 @@ class AmazonToDoHandler:
         self._session_state_data = session_state_data
         self._http_wrapper = http_wrapper
 
-        self._base_url = f"https://www.amazon.{self._session_state_data.domain}"
-
         self._lists: list[AmazonListInfo] = []
 
     @property
@@ -54,7 +52,7 @@ class AmazonToDoHandler:
         """
         _, raw_response = await self._http_wrapper.session_request(
             method,
-            f"{self._base_url}{URI_TODO}/{url}",
+            f"https://www.amazon.{self._session_state_data.domain}{URI_TODO}/{url}",
             input_data=input_data or {},  # API doesn't allow 'None'
             json_data=True,
         )


### PR DESCRIPTION
With current code `_base_url` is set as an immutable string when the handler is created.
With a new login the domain will likely change however this URL will always be pointing at .com resulting in a 401 error (until next time the API is created as that will pick up the updated domain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal URL construction logic in the To-Do handler for improved code efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->