### PR TITLE
refactor: remove async where not needed

### DIFF
--- a/src/aioamazondevices/implementation/device.py
+++ b/src/aioamazondevices/implementation/device.py
@@ -184,7 +184,7 @@ class AmazonDeviceHandler:
         endpoint_data = await self._http_wrapper.response_to_json(raw_resp, "endpoint")
 
         if not (data := endpoint_data.get("data")) or not data.get("alexaVoiceDevices"):
-            await format_graphql_error(endpoint_data)
+            format_graphql_error(endpoint_data)
             return {}
 
         devices_endpoints: dict[str, dict[str, Any]] = {}

--- a/src/aioamazondevices/implementation/notification.py
+++ b/src/aioamazondevices/implementation/notification.py
@@ -79,7 +79,7 @@ class AmazonNotificationHandler:
                 schedule["type"] = NOTIFICATION_ALARM
             label_desc = schedule_type.lower() + "Label"
             if (schedule_status := schedule["status"]) == "ON" and (
-                next_occurrence := await self._parse_next_occurrence(schedule)
+                next_occurrence := self._parse_next_occurrence(schedule)
             ):
                 schedule_notification_list = final_notifications.get(
                     schedule_device_serial, {}
@@ -113,7 +113,7 @@ class AmazonNotificationHandler:
 
         return final_notifications
 
-    async def _parse_next_occurrence(
+    def _parse_next_occurrence(
         self,
         schedule: dict[str, Any],
     ) -> datetime | None:
@@ -150,7 +150,7 @@ class AmazonNotificationHandler:
             for recurring_rule in recurring_rules:
                 # Already in RFC5545 format
                 if "FREQ=" in recurring_rule:
-                    rule = await self._add_hours_minutes(recurring_rule, original_time)
+                    rule = self._add_hours_minutes(recurring_rule, original_time)
 
                     # `after` may return None when no next occurrence exists.
                     candidate = rrulestr(rule, dtstart=reference_start_date).after(
@@ -175,7 +175,7 @@ class AmazonNotificationHandler:
                         recurring_pattern |= WEEKEND_EXCEPTIONS[group]
                         break
 
-                rule = await self._add_hours_minutes(
+                rule = self._add_hours_minutes(
                     recurring_pattern[recurring_rule], original_time
                 )
 
@@ -211,7 +211,7 @@ class AmazonNotificationHandler:
 
         return None
 
-    async def _add_hours_minutes(
+    def _add_hours_minutes(
         self,
         recurring_rule: str,
         original_time: str | None,

--- a/src/aioamazondevices/implementation/sensor.py
+++ b/src/aioamazondevices/implementation/sensor.py
@@ -128,7 +128,7 @@ class AmazonSensorHandler:
 
         sensors_state = await self._http_wrapper.response_to_json(raw_resp, "sensors")
 
-        if await format_graphql_error(sensors_state):
+        if format_graphql_error(sensors_state):
             # Explicit error in returned data
             return {}
 

--- a/src/aioamazondevices/utils.py
+++ b/src/aioamazondevices/utils.py
@@ -182,7 +182,7 @@ def parse_device_details(model: str | None) -> tuple[str | None, str | None]:
     return model, None
 
 
-async def format_graphql_error(graphql_response: dict[str, Any]) -> bool:
+def format_graphql_error(graphql_response: dict[str, Any]) -> bool:
     """Format human readable e rror from malformed data."""
     if graphql_response.get(ARRAY_WRAPPER):
         error = graphql_response[ARRAY_WRAPPER][0].get("errors", [])


### PR DESCRIPTION
just a tiny tweak AI picked up on.   There are a couple of functions that are currently async but do not need to be

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal GraphQL error handling to avoid unnecessary async waits.
  * Updated notification scheduling/parsing to run synchronously for smoother next-occurrence computation.
  * Adjusted sensor state retrieval error handling to consistently return an empty state when needed.
* **Performance**
  * Reduced overhead in device, notification, and sensor update flows by removing extra asynchronous calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->