### PR TITLE
fix: communication preferences

### DIFF
--- a/src/aioamazondevices/implementation/communication.py
+++ b/src/aioamazondevices/implementation/communication.py
@@ -83,16 +83,20 @@ class AlexaCommunicationsHandler:
             resp_json = await self._http_wrapper.response_to_json(resp)
 
             device_communication_preferences: dict[str, str] = {}
-            for device_prefs in resp_json.get("devicePermissionsPreferences", {}):
+            for device_permissions_pref in resp_json.get(
+                "devicePermissionsPreferences", {}
+            ):
                 if (
-                    device_prefs.get("devicePreference") == "communications"
-                    and device_prefs.get("allowed") is False
-                ):
+                    device_prefs := device_permissions_pref.get("devicePreference")
+                ) == "communications" and device_permissions_pref.get(
+                    "allowed"
+                ) is False:
+                    # Force empty data if communications are not allowed for the device
                     device_communication_preferences = {}
                     break
-                device_communication_preferences[
-                    device_prefs.get("devicePreference")
-                ] = device_prefs.get("state")
+                device_communication_preferences[device_prefs] = (
+                    device_permissions_pref.get("state")
+                )
 
             communication_preferences[device.serial_number] = (
                 device_communication_preferences

--- a/src/aioamazondevices/implementation/communication.py
+++ b/src/aioamazondevices/implementation/communication.py
@@ -82,18 +82,20 @@ class AlexaCommunicationsHandler:
             )
             resp_json = await self._http_wrapper.response_to_json(resp)
 
-            comms_preferences: dict[str, str] = {}
+            device_communication_preferences: dict[str, str] = {}
             for device_prefs in resp_json.get("devicePermissionsPreferences", {}):
                 if (
                     device_prefs.get("devicePreference") == "communications"
                     and device_prefs.get("allowed") is False
                 ):
-                    comms_preferences = {}
+                    device_communication_preferences = {}
                     break
-                comms_preferences[device_prefs.get("devicePreference")] = (
-                    device_prefs.get("state")
-                )
+                device_communication_preferences[
+                    device_prefs.get("devicePreference")
+                ] = device_prefs.get("state")
 
-            communication_preferences[device.serial_number] = comms_preferences
+            communication_preferences[device.serial_number] = (
+                device_communication_preferences
+            )
 
         return communication_preferences

--- a/src/aioamazondevices/implementation/communication.py
+++ b/src/aioamazondevices/implementation/communication.py
@@ -65,8 +65,6 @@ class AlexaCommunicationsHandler:
             query_string = {
                 "devicePreferences": [
                     "communications",
-                    "calling",
-                    "messaging",
                     "dropin",
                     "announcements",
                 ]
@@ -84,8 +82,14 @@ class AlexaCommunicationsHandler:
             )
             resp_json = await self._http_wrapper.response_to_json(resp)
 
-            comms_preferences = {}
+            comms_preferences: dict[str, str] = {}
             for device_prefs in resp_json.get("devicePermissionsPreferences", {}):
+                if (
+                    device_prefs.get("devicePreference") == "communications"
+                    and device_prefs.get("allowed") is False
+                ):
+                    comms_preferences = {}
+                    break
                 comms_preferences[device_prefs.get("devicePreference")] = (
                     device_prefs.get("state")
                 )

--- a/src/aioamazondevices/implementation/sensor.py
+++ b/src/aioamazondevices/implementation/sensor.py
@@ -68,10 +68,9 @@ class AmazonSensorHandler:
             ) and device.device_family != SPEAKER_GROUP_FAMILY:
                 device.sensors["dnd"] = device_dnd
 
-            if (
-                device_comm := communications.get(device.serial_number)
-            ) and device.device_family != SPEAKER_GROUP_FAMILY:
-                device.communication_settings = device_comm
+            device.communication_settings = (
+                communications.get(device.serial_number) or {}
+            )
 
             if notifications is None:
                 continue  # notifications were not obtained, do not update


### PR DESCRIPTION
remove redundant values from request (avoids typing issues)
only set communication preferences if device says communications are allowed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved communication preferences handling by refining how preferences are requested and parsed, including correctly reflecting when communications are disabled.
  * Updated device communication settings syncing so each device receives the latest communication settings (or an empty set when unavailable), including speaker-group devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->