### PR TITLE
fix: only return 'allowed' comms preferences

### DIFF
--- a/src/aioamazondevices/implementation/communication.py
+++ b/src/aioamazondevices/implementation/communication.py
@@ -86,17 +86,12 @@ class AlexaCommunicationsHandler:
             for device_permissions_pref in resp_json.get(
                 "devicePermissionsPreferences", {}
             ):
-                if (
-                    device_prefs := device_permissions_pref.get("devicePreference")
-                ) == "communications" and device_permissions_pref.get(
-                    "allowed"
-                ) is False:
-                    # Force empty data if communications are not allowed for the device
-                    device_communication_preferences = {}
-                    break
-                device_communication_preferences[device_prefs] = (
-                    device_permissions_pref.get("state")
-                )
+                device_pref = device_permissions_pref.get("devicePreference")
+                pref_state = device_permissions_pref.get("state")
+                pref_allowed = device_permissions_pref.get("allowed")
+
+                if pref_allowed is True:
+                    device_communication_preferences[device_pref] = pref_state
 
             communication_preferences[device.serial_number] = (
                 device_communication_preferences

--- a/src/aioamazondevices/implementation/communication.py
+++ b/src/aioamazondevices/implementation/communication.py
@@ -86,11 +86,11 @@ class AlexaCommunicationsHandler:
             for device_permissions_pref in resp_json.get(
                 "devicePermissionsPreferences", {}
             ):
-                device_pref = device_permissions_pref.get("devicePreference")
+                device_pref = device_permissions_pref["devicePreference"]
                 pref_state = device_permissions_pref.get("state")
                 pref_allowed = device_permissions_pref.get("allowed")
 
-                if device_pref and pref_allowed is True:
+                if pref_allowed is True:
                     device_communication_preferences[device_pref] = pref_state
 
             communication_preferences[device.serial_number] = (

--- a/src/aioamazondevices/implementation/communication.py
+++ b/src/aioamazondevices/implementation/communication.py
@@ -90,7 +90,7 @@ class AlexaCommunicationsHandler:
                 pref_state = device_permissions_pref.get("state")
                 pref_allowed = device_permissions_pref.get("allowed")
 
-                if pref_allowed is True:
+                if device_pref and pref_allowed is True:
                     device_communication_preferences[device_pref] = pref_state
 
             communication_preferences[device.serial_number] = (


### PR DESCRIPTION
Caters for scenarios such as fire TV stick which supports comms and announcements but not dropin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed communication preference parsing and handling for Amazon devices. The system now correctly extracts and filters individual permission entries based on their specific allowance status, rather than clearing all preferences when communication restrictions are detected. This ensures more accurate preservation, processing, and display of user communication preference settings while respecting permission configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->