### PR TITLE
fix: bypass comms unavailable error

### DIFF
--- a/src/aioamazondevices/implementation/communication.py
+++ b/src/aioamazondevices/implementation/communication.py
@@ -85,7 +85,8 @@ class AlexaCommunicationsHandler:
                 )
             except CannotRetrieveData:
                 _LOGGER.warning(
-                    "Failed to refresh communications settings for device %s, used cached values.", device.account_name
+                    "Failed to refresh communications settings for device %s, used cached values.",  # noqa: E501
+                    device.account_name,
                 )
                 continue
             resp_json = await self._http_wrapper.response_to_json(

--- a/src/aioamazondevices/implementation/communication.py
+++ b/src/aioamazondevices/implementation/communication.py
@@ -62,7 +62,7 @@ class AlexaCommunicationsHandler:
         self, devices: list[AmazonDevice]
     ) -> dict[str, dict[str, str]]:
         """Get communication preferences for a device."""
-        communication_preferences = {}
+        communication_preferences: dict[str, dict[str, str]] = {}
         for device in devices:
             query_string = {
                 "devicePreferences": [
@@ -86,7 +86,9 @@ class AlexaCommunicationsHandler:
             except CannotRetrieveData as e:
                 if str(e) == "Request failed: Service Unavailable":
                     _LOGGER.debug("unable to get comms preferences")
-                    return {}
+                    # no point continuing to try other devices as they
+                    # will also fail.   Just return what we have so far
+                    return communication_preferences
                 raise
             resp_json = await self._http_wrapper.response_to_json(resp)
 

--- a/src/aioamazondevices/implementation/communication.py
+++ b/src/aioamazondevices/implementation/communication.py
@@ -5,8 +5,10 @@ from http import HTTPMethod
 from yarl import URL
 
 from aioamazondevices.const.http import COMM_SITE, URI_COMM_PREFERENCES
+from aioamazondevices.exceptions import CannotRetrieveData
 from aioamazondevices.http_wrapper import AmazonHttpWrapper, AmazonSessionStateData
 from aioamazondevices.structures import AmazonDevice, AmazonDropInStatus
+from aioamazondevices.utils import _LOGGER
 
 
 class AlexaCommunicationsHandler:
@@ -77,9 +79,15 @@ class AlexaCommunicationsHandler:
                 ),
             )
             url = url.with_query(query_string)
-            _, resp = await self._http_wrapper.session_request(
-                method=HTTPMethod.GET, url=url
-            )
+            try:
+                _, resp = await self._http_wrapper.session_request(
+                    method=HTTPMethod.GET, url=url
+                )
+            except CannotRetrieveData as e:
+                if str(e) == "Request failed: Service Unavailable":
+                    _LOGGER.debug("unable to get comms preferences")
+                    return {}
+                raise
             resp_json = await self._http_wrapper.response_to_json(resp)
 
             device_communication_preferences: dict[str, str] = {}

--- a/src/aioamazondevices/implementation/communication.py
+++ b/src/aioamazondevices/implementation/communication.py
@@ -23,6 +23,7 @@ class AlexaCommunicationsHandler:
         self._session_state_data = session_state_data
         self._http_wrapper = http_wrapper
         self._communication_site = URL(COMM_SITE)
+        self._communication_preferences: dict[str, dict[str, str]] = {}
 
     async def _set_communications_state(
         self, preference: str, device: AmazonDevice, state: str
@@ -62,7 +63,6 @@ class AlexaCommunicationsHandler:
         self, devices: list[AmazonDevice]
     ) -> dict[str, dict[str, str]]:
         """Get communication preferences for a device."""
-        communication_preferences: dict[str, dict[str, str]] = {}
         for device in devices:
             query_string = {
                 "devicePreferences": [
@@ -83,13 +83,11 @@ class AlexaCommunicationsHandler:
                 _, resp = await self._http_wrapper.session_request(
                     method=HTTPMethod.GET, url=url
                 )
-            except CannotRetrieveData as e:
-                if str(e) == "Request failed: Service Unavailable":
-                    _LOGGER.debug("unable to get comms preferences")
-                    # no point continuing to try other devices as they
-                    # will also fail.   Just return what we have so far
-                    return communication_preferences
-                raise
+            except CannotRetrieveData:
+                _LOGGER.warning(
+                    "Failed to refresh communications settings, maybe stale."
+                )
+                continue
             resp_json = await self._http_wrapper.response_to_json(
                 resp, "devicesTypes(preferences)"
             )
@@ -105,8 +103,8 @@ class AlexaCommunicationsHandler:
                 if pref_allowed is True:
                     device_communication_preferences[device_pref] = pref_state
 
-            communication_preferences[device.serial_number] = (
+            self._communication_preferences[device.serial_number] = (
                 device_communication_preferences
             )
 
-        return communication_preferences
+        return self._communication_preferences

--- a/src/aioamazondevices/implementation/communication.py
+++ b/src/aioamazondevices/implementation/communication.py
@@ -85,7 +85,7 @@ class AlexaCommunicationsHandler:
                 )
             except CannotRetrieveData:
                 _LOGGER.warning(
-                    "Failed to refresh communications settings, maybe stale."
+                    "Failed to refresh communications settings for device %s, used cached values.", device.account_name
                 )
                 continue
             resp_json = await self._http_wrapper.response_to_json(


### PR DESCRIPTION
I don't particularly like it but currently users are unable to set up or start the integration at all.
I think as a temporary measure we should bypass the error and see if this does go away or whether we need to do something different

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when refreshing communication settings for devices.
  * If a device’s settings can’t be retrieved, the app now skips that device and continues processing the rest instead of failing the whole refresh.
  * Updated communication preferences are now kept more consistently across refreshes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->