### PR TITLE
fix: add cookies for global sites

### DIFF
--- a/src/aioamazondevices/http_wrapper.py
+++ b/src/aioamazondevices/http_wrapper.py
@@ -347,6 +347,11 @@ class AmazonHttpWrapper:
                 scheme="https", host=f".amazon.{self._session_state_data.domain}"
             ),
         )
+        # Needed for global endpoints like COMM_SITE and HTTP2_SITE
+        if self._session_state_data.domain != "com":
+            await self.set_cookies(
+                _cookies, URL.build(scheme="https", host=".amazon.com")
+            )
 
         resp: ClientResponse | None = None
         for delay in [0, 1, 2, 5, 8, 12, 21]:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cookie handling for Amazon requests when using non-U.S. regional domains.
  * Added support for sending additional cookies to the `.amazon.com` domain, helping requests work more reliably on global Amazon endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->