### PR TITLE
fix: skip comms calls for devices that cannot be controlled

### DIFF
--- a/src/aioamazondevices/implementation/communication.py
+++ b/src/aioamazondevices/implementation/communication.py
@@ -4,6 +4,7 @@ from http import HTTPMethod
 
 from yarl import URL
 
+from aioamazondevices.const.devices import DEVICE_TYPE_AQM, SPEAKER_GROUP_FAMILY
 from aioamazondevices.const.http import COMM_SITE, URI_COMM_PREFERENCES
 from aioamazondevices.exceptions import CannotRetrieveData
 from aioamazondevices.http_wrapper import AmazonHttpWrapper, AmazonSessionStateData
@@ -64,6 +65,12 @@ class AlexaCommunicationsHandler:
     ) -> dict[str, dict[str, str]]:
         """Get communication preferences for a device."""
         for device in devices:
+            if (
+                device.device_family == SPEAKER_GROUP_FAMILY
+                or device.device_type == DEVICE_TYPE_AQM
+            ):
+                continue
+
             query_string = {
                 "devicePreferences": [
                     "communications",

--- a/src/aioamazondevices/implementation/communication.py
+++ b/src/aioamazondevices/implementation/communication.py
@@ -69,8 +69,7 @@ class AlexaCommunicationsHandler:
                 device.device_family == SPEAKER_GROUP_FAMILY
                 or device.device_type == DEVICE_TYPE_AQM
             ):
-                # avoid unnecessary call for devices we know don't support
-                # communications
+                # avoid unnecessary call for devices that don't support communications
                 continue
 
             query_string = {

--- a/src/aioamazondevices/implementation/communication.py
+++ b/src/aioamazondevices/implementation/communication.py
@@ -69,6 +69,8 @@ class AlexaCommunicationsHandler:
                 device.device_family == SPEAKER_GROUP_FAMILY
                 or device.device_type == DEVICE_TYPE_AQM
             ):
+                # avoid unnecessary call for devices we know don't support
+                # communications
                 continue
 
             query_string = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device handling so communication preferences are no longer fetched for unsupported speaker group and AQM device types.
  * Prevented these devices from being added to communication preference results, reducing unnecessary processing and incorrect updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->