### PR TITLE
Handle PUSH_NOTIFICATION_CHANGE push events

### DIFF
--- a/src/aioamazondevices/api.py
+++ b/src/aioamazondevices/api.py
@@ -144,6 +144,7 @@ class AmazonEchoApi:
         self.on_volume_state_event = Signal[dict[str, AmazonVolumeState]](self)
         self.on_history_event = Signal[dict[str, AmazonVocalRecord]](self)
         self.on_todo_event = Signal[AmazonListEvent](self)
+        self.on_notification_event = Signal[dict[str, AmazonDevice]](self)
 
     @property
     def domain(self) -> str:
@@ -291,6 +292,9 @@ class AmazonEchoApi:
                 await self._handle_audio_player_state_event()
             case AmazonPushMessage.ItemChange.value:
                 await self._handle_item_change_event(payload)
+            case AmazonPushMessage.NotificationChange.value:
+                serial_number = payload.get("dopplerId", {}).get("deviceSerialNumber")
+                await self._handle_notification_change_event(serial_number)
             case _:
                 _LOGGER.debug("Unhandled push event type: %s", event_type)
 
@@ -323,6 +327,28 @@ class AmazonEchoApi:
 
         await self._media_handler.sync_media_state(self._device_handler.devices)
         await self._emit_media_state_event()
+
+    async def _handle_notification_change_event(
+        self, serial_number: str | None
+    ) -> None:
+        if not self._device_handler.devices:
+            _LOGGER.debug(
+                "Skipping notification sync for push event because devices "
+                "have not been loaded yet"
+            )
+            return
+
+        notifications = await self._notification_handler.get_notifications()
+        if notifications is None:
+            _LOGGER.debug("Notification fetch returned None, skipping update")
+            return
+
+        self._sensor_handler.handle_push_notification_update(
+            self._device_handler.devices,
+            notifications,
+            serial_number,
+        )
+        await self._emit_notification_event()
 
     async def _handle_item_change_event(self, payload: dict[str, Any]) -> None:
         list_id = payload.get("listId")
@@ -521,6 +547,12 @@ class AmazonEchoApi:
             await self.on_volume_state_event.send(
                 await self._media_handler.device_volumes
             )
+
+    async def _emit_notification_event(self) -> None:
+        """Emit notification event to subscribers."""
+        if self.on_notification_event.frozen:
+            _LOGGER.debug("Emitting notification event to subscribers")
+            await self.on_notification_event.send(self._device_handler.devices)
 
     async def _emit_todo_event(self, list_event: AmazonListEvent) -> None:
         """Emit todo event to subscribers."""

--- a/src/aioamazondevices/implementation/sensor.py
+++ b/src/aioamazondevices/implementation/sensor.py
@@ -72,16 +72,44 @@ class AmazonSensorHandler:
                 communications.get(device.serial_number) or {}
             )
 
-            if notifications is None:
-                continue  # notifications were not obtained, do not update
+        self._update_notifications(self._final_devices, notifications)
 
-            # Clear old notifications to handle cancelled ones
+        # base online status of speaker groups on their members
+        for device in self._final_devices.values():
+            if device.device_family == SPEAKER_GROUP_FAMILY:
+                device.online = all(
+                    d.online
+                    for d in self._final_devices.values()
+                    if d.serial_number in device.device_cluster_members
+                )
+
+    def handle_push_notification_update(
+        self,
+        devices: dict[str, AmazonDevice],
+        notifications: dict[str, dict[str, Any]] | None,
+        serial_number: str | None = None,
+    ) -> None:
+        """Apply notification data from a push event for a specific device."""
+        self._update_notifications(devices, notifications, serial_number)
+
+    def _update_notifications(
+        self,
+        devices: dict[str, AmazonDevice],
+        notifications: dict[str, dict[str, Any]] | None,
+        serial_number: str | None = None,
+    ) -> None:
+        """Update notification data on devices."""
+        if notifications is None:
+            return
+
+        targets = (
+            [devices[serial_number]]
+            if serial_number and serial_number in devices
+            else list(devices.values())
+        )
+        for device in targets:
             device.notifications = {}
-
-            # Update notifications
             device_notifications = notifications.get(device.serial_number, {})
-
-            # Add only supported notification types
             for capability, notification_type in [
                 ("REMINDERS", NOTIFICATION_REMINDER),
                 ("TIMERS_AND_ALARMS", NOTIFICATION_ALARM),
@@ -97,15 +125,6 @@ class AmazonSensorHandler:
                     )
                 ):
                     device.notifications[notification_type] = notification_object
-
-        # base online status of speaker groups on their members
-        for device in self._final_devices.values():
-            if device.device_family == SPEAKER_GROUP_FAMILY:
-                device.online = all(
-                    d.online
-                    for d in self._final_devices.values()
-                    if d.serial_number in device.device_cluster_members
-                )
 
     async def _get_sensors_states(self) -> dict[str, dict[str, AmazonDeviceSensor]]:
         """Retrieve devices sensors states."""


### PR DESCRIPTION
## Problem

Amazon sends `PUSH_NOTIFICATION_CHANGE` when a timer, alarm, or reminder is created, updated, or deleted on a device. The event type is already defined in `AmazonPushMessage.NotificationChange` and correctly recognised (and duplicate-filtered) by the HTTP/2 parser, but `_http2_push_event_handler` has no `case` for it. The event therefore falls through to the catch-all `_LOGGER.debug("Unhandled push event type: %s", event_type)` branch and timer/alarm/reminder sensors are never updated until the next scheduled poll (default: every 5 minutes in the Home Assistant integration).

### Log evidence (Home Assistant 2026.7.2 / aioamazondevices 14.1.9)

The following excerpt was captured at the moment a 1-minute timer was set by voice on an Echo device (2026-07-21 ~19:10 Europe/Rome):

```
2026-07-21 19:10:56.420 DEBUG [aioamazondevices] Failed to process rendering update: {
  'resourceId': 'PUSH_NOTIFICATION_CHANGE',
  'resourceMetadata': {
    'command': 'PUSH_NOTIFICATION_CHANGE',
    'payload': {
      'dopplerId': {'deviceSerialNumber': 'G090XG09002303Q0', 'deviceType': 'A1RABVCI4QCIKC'},
      'notificationId': '9bac1c2e-07e0-396f-8af6-d1c5f13dcd55',
      'notificationVersion': 2,
      'eventType': 'UPDATE',
      'destinationUserId': 'A25O4ECFICAYDB'
    },
    'timeStamp': 1784653856364
  }
}

2026-07-21 19:10:56.675 DEBUG [aioamazondevices] Detected push event type <PUSH_NOTIFICATION_CHANGE> on device <G090XG09002303Q0>
2026-07-21 19:10:56.675 DEBUG [aioamazondevices] Event - PUSH_NOTIFICATION_CHANGE : Payload - {
  'dopplerId': {'deviceSerialNumber': 'G090XG09002303Q0', 'deviceType': 'A1RABVCI4QCIKC'},
  'notificationId': '9bac1c2e-07e0-396f-8af6-d1c5f13dcd55',
  'notificationVersion': 3,
  'eventType': 'UPDATE',
  'destinationUserId': 'A25O4ECFICAYDB'
}
2026-07-21 19:10:56.675 DEBUG [aioamazondevices] Unhandled push event type: PUSH_NOTIFICATION_CHANGE
```

`notificationVersion=2` is correctly discarded as a duplicate by the existing filter; `notificationVersion=3` reaches the dispatcher but is dropped because there is no handler for it.

## Solution

- Add `on_notification_event: Signal[dict[str, AmazonDevice]]` so consumers can react to notification changes in real time (same pattern as `on_volume_state_event`, `on_history_event`, etc.).
- Add `_handle_notification_change_event` that calls `get_notifications()` and delegates to the new `AmazonSensorHandler.update_notifications`.
- Extract `AmazonSensorHandler.update_notifications` as a public sync method that updates only `device.notifications` for all devices, without triggering a full `update_sensor_data` cycle (which would also re-query GraphQL sensor state and DnD status).
- Add `_emit_notification_event` following the same pattern as the other emit helpers.

## Testing

Tested on a live Home Assistant 2026.7.2 instance with aioamazondevices 14.1.9 (Python 3.14). After applying this fix and the companion Home Assistant Core PR (home-assistant/core#177023 — see below), setting a 1-minute timer by voice on an Alexa device caused the timer sensor entity to update immediately instead of waiting for the next 5-minute poll.

> **Note for the HA Core maintainers:** a companion PR is open at home-assistant/core to wire up the new `on_notification_event` signal in `AmazonDevicesCoordinator` — see [home-assistant/core#177023](https://github.com/home-assistant/core/pull/177023). That PR depends on this library change being released first.

## Checklist

- [x] The code change is tested and works locally
- [x] Local tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added real-time notification change handling through the event pipeline.
  * Notification-related sensor states now refresh automatically when updates arrive.
  * Added an event signal that broadcasts the latest device notification state.
  * Refreshed supported reminders, alarms, and timers based on each device’s capabilities.
  * Updates can be applied to a specific device or across all devices.

* **Refactor**
  * Improved notification refresh flow for more consistent sensor updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->