### PR TITLE
feat: add Amazon thermostat support

### DIFF
--- a/library_test.py
+++ b/library_test.py
@@ -30,6 +30,7 @@ from aioamazondevices.exceptions import (
     CannotAuthenticate,
     CannotConnect,
     CannotRegisterDevice,
+    CannotSetThermostat,
     NoOnlineDevicesError,
 )
 from aioamazondevices.structures import (
@@ -88,6 +89,12 @@ async def get_arguments() -> tuple[ArgumentParser, Namespace]:
         "-rn",
         type=str,
         help="Routine name to execute for testing",
+    )
+    parser.add_argument(
+        "--thermostat_device_name",
+        "-tdn",
+        type=str,
+        help="Thermostat device name to exercise set_thermostat_* calls on",
     )
     parser.add_argument(
         "--configfile",
@@ -317,6 +324,12 @@ async def main() -> None:
             print(f"   Device hardware version: {device.hardware_version}")
             print(f"   Device software version: {device.software_version}")
             print(f"   Device sensors: {len(device.sensors)}")
+            if (thermostat := device.sensors.get("thermostat")) and isinstance(
+                thermostat.value, dict
+            ):
+                print("   Thermostat data:")
+                for key, value in thermostat.value.items():
+                    print(f"     {key}: {value}")
             print(f"   Device notifications: {len(device.notifications)}")
             print(f"   Device communications: {device_comm_settings}")
             dev_index += 1
@@ -522,6 +535,62 @@ async def tests(
         print(f"Executing routine '{args.routine_name}'")
         await api.call_routine(args.routine_name)
         await wait_action_complete(10)
+
+    # Unlike the tests above, this defaults to False (not True): it has a real
+    # physical effect on the thermostat, so it must be explicitly opted into.
+    if args.tests.get("11_test_thermostat", False):
+        await test_thermostat(api, devices, args.thermostat_device_name)
+
+
+def _is_thermostat(device: AmazonDevice) -> bool:
+    """Return whether a device is a thermostat."""
+    return device.device_family == "THERMOSTAT"
+
+
+async def test_thermostat(
+    api: AmazonEchoApi, devices: dict[str, AmazonDevice], device_name: str | None
+) -> None:
+    """Exercise set_thermostat_* by re-setting the mode/setpoint(s) already active.
+
+    A round-trip no-op: it changes nothing about the thermostat's comfort
+    settings, but still exercises the write path end-to-end against the
+    real API.
+    """
+    device = find_device(devices, device_name, _is_thermostat)
+    thermostat = device.sensors.get("thermostat")
+    if not thermostat or not isinstance(thermostat.value, dict):
+        print(f"No thermostat data for {device.account_name}, skipping thermostat test")
+        return
+
+    data = thermostat.value
+    scale = data.get("temperatureScale", "FAHRENHEIT")
+    mode = data.get("thermostatMode")
+
+    try:
+        if mode == "AUTO" and "lowerSetpoint" in data and "upperSetpoint" in data:
+            lower = data["lowerSetpoint"]
+            upper = data["upperSetpoint"]
+            print(
+                f"Re-setting existing AUTO range {lower}-{upper}{scale} "
+                f"on {device.account_name}"
+            )
+            await api.set_thermostat_temperature_range(device, lower, upper, scale)
+            await wait_action_complete()
+        elif "targetSetpoint" in data:
+            target = data["targetSetpoint"]
+            print(
+                f"Re-setting existing target setpoint {target}{scale} "
+                f"on {device.account_name}"
+            )
+            await api.set_thermostat_target_temperature(device, target, scale)
+            await wait_action_complete()
+
+        if mode:
+            print(f"Re-setting existing mode {mode} on {device.account_name}")
+            await api.set_thermostat_mode(device, mode)
+            await wait_action_complete()
+    except CannotSetThermostat as exc:
+        print(f"Thermostat control failed: {exc}")
 
 
 def set_logging() -> None:

--- a/ruff.toml
+++ b/ruff.toml
@@ -20,7 +20,8 @@ lint.ignore = [
 
 [lint.per-file-ignores]
 "library_test.py" = [
-    "ASYNC250",  # Blocking call to `input()` in async context 
+    "ASYNC250",  # Blocking call to `input()` in async context
+    "C901",      # too complex (a flat sequence of independent opt-in test toggles)
     "PLR0915",   # Too many statements
     "T201",      # `print` found
 ]

--- a/src/aioamazondevices/api.py
+++ b/src/aioamazondevices/api.py
@@ -36,6 +36,7 @@ from .implementation.history import AmazonHistoryHandler
 from .implementation.http2 import AmazonHTTP2Client
 from .implementation.notification import AmazonNotificationHandler
 from .implementation.sequence import AmazonSequenceHandler
+from .implementation.thermostat import AmazonThermostatHandler
 from .login import AmazonLogin
 from .structures import (
     AmazonDevice,
@@ -137,6 +138,11 @@ class AmazonEchoApi:
         )
 
         self._communication_handler = AlexaCommunicationsHandler(
+            http_wrapper=self._http_wrapper,
+            session_state_data=self._session_state_data,
+        )
+
+        self._thermostat_handler = AmazonThermostatHandler(
             http_wrapper=self._http_wrapper,
             session_state_data=self._session_state_data,
         )
@@ -543,6 +549,22 @@ class AmazonEchoApi:
     async def set_announcement_status(self, device: AmazonDevice, enable: bool) -> None:
         """Set announcements enabled status for a device."""
         await self._communication_handler.set_announcement_status(device, enable)
+
+    async def set_thermostat_mode(self, device: AmazonDevice, mode: str) -> None:
+        """Set a thermostat's HVAC mode (e.g. HEAT, COOL, AUTO, OFF)."""
+        await self._thermostat_handler.set_thermostat_mode(device, mode)
+
+    async def set_thermostat_target_temperature(
+        self, device: AmazonDevice, temperature: float, scale: str
+    ) -> None:
+        """Set a thermostat's single target temperature (HEAT/COOL mode)."""
+        await self._thermostat_handler.set_target_setpoint(device, temperature, scale)
+
+    async def set_thermostat_temperature_range(
+        self, device: AmazonDevice, lower: float, upper: float, scale: str
+    ) -> None:
+        """Set a thermostat's heat/cool target range (AUTO mode)."""
+        await self._thermostat_handler.set_setpoint_range(device, lower, upper, scale)
 
     async def sync_media_state(self) -> None:
         """Sync media state.

--- a/src/aioamazondevices/const/devices.py
+++ b/src/aioamazondevices/const/devices.py
@@ -13,6 +13,7 @@ DEVICE_TYPE_ECHO_SPOT_GEN1 = "A10A33FOX2NUBK"
 DEVICE_TYPE_SPEAKER_GROUP = "A3C9PE6TNYLTCH"
 DEVICE_TYPE_STEREO_PAIR = "AP1F6KUH00XPV"
 DEVICE_TYPE_AUTO_GEN2 = "A13W6HQIHKEN3Z"
+DEVICE_TYPE_THERMOSTAT = "A39QOBV8YPBZIY"
 
 DEVICE_TYPES_HARDCODED_METADATA: dict[str, dict[str, str]] = {
     DEVICE_TYPE_AQM: {
@@ -37,6 +38,10 @@ DEVICE_TYPES_HARDCODED_METADATA: dict[str, dict[str, str]] = {
     },
     DEVICE_TYPE_STEREO_PAIR: {
         "model": "Stereo Pair",
+        "manufacturer": "Amazon",
+    },
+    DEVICE_TYPE_THERMOSTAT: {
+        "model": "Smart Thermostat",
         "manufacturer": "Amazon",
     },
 }

--- a/src/aioamazondevices/const/queries.py
+++ b/src/aioamazondevices/const/queries.py
@@ -22,6 +22,15 @@ query getDevicesBaseData {
   ) {
     ...DeviceEndpoints
   }
+
+  thermostats: listEndpoints(
+    listEndpointsInput: {
+      displayCategory: "THERMOSTAT"
+      includeHouseholdDevices: true
+    }
+  ) {
+    ...DeviceEndpoints
+  }
 }
 
 fragment DeviceEndpoints on ListEndpointsResponse {
@@ -95,6 +104,33 @@ fragment EndpointState on Endpoint {
         timeOfSample
         timeOfLastChange
       }
+      ... on Setpoint {
+        value { value scale }
+        timeOfSample
+        timeOfLastChange
+      }
+      ... on ThermostatMode {
+        thermostatModeValue
+        timeOfSample
+        timeOfLastChange
+      }
+      ... on ThermostatConfigurationAllowedTemperatureRange {
+        thermostatAllowedTemperatureRangeValue {
+          heating { minimum { value scale } maximum { value scale } }
+          cooling { minimum { value scale } maximum { value scale } }
+        }
+        timeOfSample
+        timeOfLastChange
+      }
+    }
+    configuration {
+      __typename
+      ... on ThermostatConfiguration {
+        supportedModes
+      }
+      ... on RangeConfiguration {
+        friendlyName { value { text } }
+      }
     }
   }
 }
@@ -111,6 +147,29 @@ query getEndpointState($endpointIds: [String]!) {
     endpoints {
       ...EndpointState
     }
+  }
+}
+"""
+
+MUTATION_SET_ENDPOINT_FEATURE = """
+mutation setEndpointFeature($featureControlRequests: [FeatureControlRequest!]!) {
+  setEndpointFeatures(
+    setEndpointFeaturesInput: { featureControlRequests: $featureControlRequests }
+  ) {
+    errors {
+      __typename
+      message
+      code
+      featureOperationName
+      endpointId
+    }
+    featureControlResponses {
+      __typename
+      featureName
+      featureOperationName
+      endpointId
+    }
+    __typename
   }
 }
 """

--- a/src/aioamazondevices/exceptions.py
+++ b/src/aioamazondevices/exceptions.py
@@ -22,6 +22,10 @@ class CannotRestartDevice(AmazonError):
     """Exception raised when device restart fails."""
 
 
+class CannotSetThermostat(AmazonError):
+    """Exception raised when a thermostat control mutation fails."""
+
+
 class CannotRetrieveData(AmazonError):
     """Exception raised when data retrieval fails."""
 

--- a/src/aioamazondevices/implementation/device.py
+++ b/src/aioamazondevices/implementation/device.py
@@ -10,6 +10,7 @@ from yarl import URL
 
 from aioamazondevices.const.devices import (
     DEVICE_TYPE_AQM,
+    DEVICE_TYPE_THERMOSTAT,
     DEVICE_TYPES_HARDCODED_METADATA,
     DEVICE_TYPES_TO_IGNORE,
 )
@@ -216,52 +217,76 @@ class AmazonDeviceHandler:
                 devices_endpoints[serial_number] = endpoint
                 self._endpoints[endpoint["endpointId"]] = serial_number
 
-        # Process Air Quality Monitors if present
+        # Process Air Quality Monitors and Thermostats if present
         # map endpoint ID to serial number to facilitate sensor lookup but also
         # create AmazonDevice as these are not present in api/devices-v2/device endpoint
         for aqm_endpoint in data.get("airQualityMonitors", {}).get("endpoints", {}):
-            if (
-                aqm_endpoint.get("manufacturer", {})
-                .get("value", {})
-                .get("text", "Unknown")
-                != "Amazon"
-            ):
-                _LOGGER.debug(
-                    "Skipping non-Amazon Air Quality Monitor: %s",
-                    aqm_endpoint,
+            if not (
+                serial_number := self._register_graphql_only_device(
+                    aqm_endpoint, "AIR_QUALITY_MONITOR", DEVICE_TYPE_AQM
                 )
+            ):
                 continue
-            aqm_serial_number: str = aqm_endpoint["serialNumber"]["value"]["text"]
-            devices_endpoints[aqm_serial_number] = aqm_endpoint
-            self._endpoints[aqm_endpoint["endpointId"]] = aqm_serial_number
+            devices_endpoints[serial_number] = aqm_endpoint
+            self._endpoints[aqm_endpoint["endpointId"]] = serial_number
 
-            self._final_devices[aqm_serial_number] = AmazonDevice(
-                account_name=aqm_endpoint["friendlyNameObject"]["value"]["text"],
-                capabilities=[],
-                device_family="AIR_QUALITY_MONITOR",
-                device_type=aqm_endpoint["legacyIdentifiers"]["dmsIdentifier"][
-                    "deviceType"
-                ]["value"]["text"],
-                device_owner_customer_id=self._session_state_data.account_customer_id
-                or "n/a",
-                household_device=False,
-                device_cluster_members={aqm_serial_number: DEVICE_TYPE_AQM},
-                online=True,
-                serial_number=aqm_serial_number,
-                software_version=aqm_endpoint["softwareVersion"]["value"]["text"],
-                manufacturer="Amazon",
-                model=None,
-                hardware_version=None,
-                entity_id=None,
-                endpoint_id=aqm_endpoint.get("endpointId"),
-                sensors={},
-                notifications_supported=False,
-                notifications={},
-                media_player_supported=False,
-                communication_settings={},
-            )
+        for therm_endpoint in data.get("thermostats", {}).get("endpoints", {}):
+            if not (
+                serial_number := self._register_graphql_only_device(
+                    therm_endpoint, "THERMOSTAT", DEVICE_TYPE_THERMOSTAT
+                )
+            ):
+                continue
+            devices_endpoints[serial_number] = therm_endpoint
+            self._endpoints[therm_endpoint["endpointId"]] = serial_number
 
         return devices_endpoints
+
+    def _register_graphql_only_device(
+        self,
+        endpoint: dict[str, Any],
+        device_family: str,
+        device_type_const: str,
+    ) -> str | None:
+        """Create an AmazonDevice for an endpoint only visible via graphql.
+
+        Returns the endpoint's serial number, or None if it was skipped.
+        """
+        if (
+            endpoint.get("manufacturer", {}).get("value", {}).get("text", "Unknown")
+            != "Amazon"
+        ):
+            _LOGGER.debug("Skipping non-Amazon %s: %s", device_family, endpoint)
+            return None
+
+        serial_number: str = endpoint["serialNumber"]["value"]["text"]
+
+        self._final_devices[serial_number] = AmazonDevice(
+            account_name=endpoint["friendlyNameObject"]["value"]["text"],
+            capabilities=[],
+            device_family=device_family,
+            device_type=endpoint["legacyIdentifiers"]["dmsIdentifier"]["deviceType"][
+                "value"
+            ]["text"],
+            device_owner_customer_id=self._session_state_data.account_customer_id
+            or "n/a",
+            household_device=False,
+            device_cluster_members={serial_number: device_type_const},
+            online=True,
+            serial_number=serial_number,
+            software_version=endpoint["softwareVersion"]["value"]["text"],
+            manufacturer="Amazon",
+            model=None,
+            hardware_version=None,
+            entity_id=None,
+            endpoint_id=endpoint.get("endpointId"),
+            sensors={},
+            notifications_supported=False,
+            notifications={},
+            media_player_supported=False,
+            communication_settings={},
+        )
+        return serial_number
 
     async def restart_device(self, device: AmazonDevice) -> None:
         """Restart a device."""

--- a/src/aioamazondevices/implementation/sensor.py
+++ b/src/aioamazondevices/implementation/sensor.py
@@ -22,8 +22,20 @@ from aioamazondevices.const.schedules import (
 )
 from aioamazondevices.exceptions import CannotRetrieveData
 from aioamazondevices.http_wrapper import AmazonHttpWrapper, AmazonSessionStateData
+from aioamazondevices.implementation.thermostat import (
+    extract_thermostat_configuration_sensors,
+    extract_thermostat_sensors,
+)
 from aioamazondevices.structures import AmazonDevice, AmazonDeviceSensor
 from aioamazondevices.utils import _LOGGER, format_graphql_error
+
+
+def _range_friendly_name(feature: dict[str, Any]) -> str | None:
+    """Return a range feature's friendly name, if Amazon provided one."""
+    name = (
+        (feature.get("configuration") or {}).get("friendlyName", {}).get("value", {})
+    ).get("text")
+    return name if isinstance(name, str) else None
 
 
 class AmazonSensorHandler:
@@ -168,7 +180,18 @@ class AmazonSensorHandler:
     ) -> dict[str, AmazonDeviceSensor]:
         device_sensors: dict[str, AmazonDeviceSensor] = {}
         device = self._final_devices[serial_number]
+        thermostat_data: dict[str, Any] = {}
         for feature in endpoint.get("features", {}):
+            if feature["name"] == "thermostat":
+                thermostat_data.update(extract_thermostat_sensors(feature))
+                continue
+
+            if feature["name"] == "thermostatConfiguration":
+                thermostat_data.update(
+                    extract_thermostat_configuration_sensors(feature)
+                )
+                continue
+
             if (sensor_template := SENSORS.get(feature["name"])) is None:
                 # Skip sensors that are not in the predefined list
                 continue
@@ -230,22 +253,11 @@ class AmazonSensorHandler:
 
                 sensor_name = sensor_template_name_value
 
-                if (
-                    device.device_type == DEVICE_TYPE_AQM
-                    and sensor_template_name_value == "rangeValue"
-                ):
-                    if not (
-                        (instance := feature.get("instance"))
-                        and (aqm_sensor := AQM_RANGE_SENSORS.get(instance))
-                        and (aqm_sensor_name := aqm_sensor.get("name"))
-                    ):
-                        _LOGGER.debug(
-                            "No template for rangeValue (%s) - Skipping sensor",
-                            instance,
-                        )
+                if sensor_template_name_value == "rangeValue":
+                    resolved = self._resolve_range_sensor(device, feature, scale)
+                    if resolved is None:
                         continue
-                    sensor_name = aqm_sensor_name
-                    scale = aqm_sensor.get("scale")
+                    sensor_name, scale = resolved
 
                 device_sensors[sensor_name] = AmazonDeviceSensor(
                     sensor_name,
@@ -256,4 +268,29 @@ class AmazonSensorHandler:
                     scale,
                 )
 
+        if thermostat_data:
+            if temperature_sensor := device_sensors.pop("temperature", None):
+                thermostat_data["temperature"] = temperature_sensor.value
+            device_sensors["thermostat"] = AmazonDeviceSensor(
+                "thermostat", thermostat_data, False, None, None, None
+            )
+
         return device_sensors
+
+    def _resolve_range_sensor(
+        self, device: AmazonDevice, feature: dict[str, Any], scale: str | None
+    ) -> tuple[str, str | None] | None:
+        """Return (sensor_name, scale) for a rangeValue sensor, or None to skip it."""
+        if device.device_type != DEVICE_TYPE_AQM:
+            # Amazon labels some range features (e.g. "Indoor humidity"); use it
+            # instead of the generic name so multiple instances don't collide.
+            return _range_friendly_name(feature) or "rangeValue", scale
+
+        if not (
+            (instance := feature.get("instance"))
+            and (aqm_sensor := AQM_RANGE_SENSORS.get(instance))
+            and (aqm_sensor_name := aqm_sensor.get("name"))
+        ):
+            _LOGGER.debug("No template for rangeValue (%s) - Skipping sensor", instance)
+            return None
+        return aqm_sensor_name, aqm_sensor.get("scale")

--- a/src/aioamazondevices/implementation/thermostat.py
+++ b/src/aioamazondevices/implementation/thermostat.py
@@ -1,0 +1,211 @@
+# Copyright 2024 Simone Chemelli and contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Thermostat control module for Amazon devices."""
+
+from http import HTTPMethod
+from typing import Any
+
+from yarl import URL
+
+from aioamazondevices.const.http import ARRAY_WRAPPER, REQUEST_AGENT, URI_NEXUS_GRAPHQL
+from aioamazondevices.const.queries import MUTATION_SET_ENDPOINT_FEATURE
+from aioamazondevices.exceptions import CannotSetThermostat
+from aioamazondevices.http_wrapper import AmazonHttpWrapper, AmazonSessionStateData
+from aioamazondevices.structures import AmazonDevice
+from aioamazondevices.utils import _LOGGER, format_graphql_error
+
+# Feature "thermostat" carries several differently-named properties at once,
+# unlike single-property sensors (see const/metadata.py's SENSORS), so it is
+# keyed by property name instead.
+THERMOSTAT_SENSORS: dict[str, dict[str, str | None]] = {
+    "targetSetpoint": {
+        "key": "value",
+        "subkey": "value",
+        "scale": "scale",
+    },
+    "upperSetpoint": {
+        "key": "value",
+        "subkey": "value",
+        "scale": "scale",
+    },
+    "lowerSetpoint": {
+        "key": "value",
+        "subkey": "value",
+        "scale": "scale",
+    },
+    "thermostatMode": {
+        "key": "thermostatModeValue",
+        "subkey": None,
+        "scale": None,
+    },
+}
+
+
+def extract_thermostat_sensors(feature: dict[str, Any]) -> dict[str, Any]:
+    """Extract raw setpoint/mode values from a thermostat feature block."""
+    data: dict[str, Any] = {}
+    for feature_property in feature.get("properties") or []:
+        property_name = feature_property.get("name")
+        if (sensor_template := THERMOSTAT_SENSORS.get(property_name)) is None:
+            continue
+        if feature_property.get("error"):
+            continue
+
+        value_raw = feature_property.get(sensor_template["key"])
+        if not value_raw:
+            continue
+
+        if scale_template := sensor_template["scale"]:
+            data.setdefault("temperatureScale", value_raw[scale_template])
+        data[property_name] = (
+            value_raw[subkey_template]
+            if (subkey_template := sensor_template["subkey"])
+            else value_raw
+        )
+
+    supported_modes = (feature.get("configuration") or {}).get("supportedModes")
+    if supported_modes:
+        data["supportedModes"] = supported_modes
+
+    return data
+
+
+def extract_thermostat_configuration_sensors(feature: dict[str, Any]) -> dict[str, Any]:
+    """Extract the allowed heating/cooling temperature range values."""
+    data: dict[str, Any] = {}
+    for feature_property in feature.get("properties") or []:
+        if feature_property.get("name") != "allowedTemperatureRange":
+            continue
+        if feature_property.get("error"):
+            continue
+
+        allowed_range = (
+            feature_property.get("thermostatAllowedTemperatureRangeValue") or {}
+        )
+        for hvac_mode in ("heating", "cooling"):
+            mode_range = allowed_range.get(hvac_mode) or {}
+            for bound in ("minimum", "maximum"):
+                bound_value = mode_range.get(bound)
+                if not bound_value:
+                    continue
+                data[f"{hvac_mode}{bound.title()}Temperature"] = bound_value["value"]
+                data.setdefault("temperatureScale", bound_value.get("scale"))
+
+    return data
+
+
+class AmazonThermostatHandler:
+    """Class to handle Amazon thermostat control functionality."""
+
+    def __init__(
+        self,
+        http_wrapper: AmazonHttpWrapper,
+        session_state_data: AmazonSessionStateData,
+    ) -> None:
+        """Initialize AmazonThermostatHandler class."""
+        self._session_state_data = session_state_data
+        self._http_wrapper = http_wrapper
+
+    async def set_thermostat_mode(self, device: AmazonDevice, mode: str) -> None:
+        """Set the thermostat's HVAC mode (e.g. HEAT, COOL, AUTO, OFF)."""
+        await self._set_endpoint_feature(
+            device, "thermostat", "setThermostatMode", {"thermostatMode": mode}
+        )
+
+    async def set_target_setpoint(
+        self, device: AmazonDevice, value: float, scale: str
+    ) -> None:
+        """Set a single target temperature (HEAT/COOL mode)."""
+        await self._set_endpoint_feature(
+            device,
+            "thermostat",
+            "setTargetSetpoint",
+            {"targetSetpoint": {"value": _format_temperature(value), "scale": scale}},
+        )
+
+    async def set_setpoint_range(
+        self, device: AmazonDevice, lower: float, upper: float, scale: str
+    ) -> None:
+        """Set the heat/cool target range in one mutation (AUTO mode)."""
+        await self._set_endpoint_feature(
+            device,
+            "thermostat",
+            "setTargetSetpoint",
+            {
+                "lowerSetpoint": {
+                    "value": _format_temperature(lower),
+                    "scale": scale,
+                },
+                "upperSetpoint": {
+                    "value": _format_temperature(upper),
+                    "scale": scale,
+                },
+            },
+        )
+
+    async def _set_endpoint_feature(
+        self,
+        device: AmazonDevice,
+        feature_name: str,
+        operation_name: str,
+        payload: dict[str, Any],
+    ) -> None:
+        """Send a setEndpointFeatures mutation and raise on failure."""
+        if not device.endpoint_id:
+            raise CannotSetThermostat(
+                f"No endpoint ID for device {device.account_name}"
+            )
+
+        request = {
+            "endpointId": device.endpoint_id,
+            "featureName": feature_name,
+            "featureOperationName": operation_name,
+            "payload": payload,
+        }
+        input_data = [
+            {
+                "operationName": "setEndpointFeature",
+                "variables": {"featureControlRequests": [request]},
+                "query": MUTATION_SET_ENDPOINT_FEATURE,
+            }
+        ]
+
+        _, raw_resp = await self._http_wrapper.session_request(
+            method=HTTPMethod.POST,
+            url=URL.joinpath(
+                self._session_state_data.alexa_website_url, URI_NEXUS_GRAPHQL
+            ),
+            input_data=input_data,
+            json_data=True,
+            extended_headers={"User-Agent": REQUEST_AGENT["Amazon"]},
+        )
+        response = await self._http_wrapper.response_to_json(
+            raw_resp, "setEndpointFeature"
+        )
+
+        if format_graphql_error(response):
+            raise CannotSetThermostat(
+                f"Failed to {operation_name} for {device.account_name}"
+            )
+
+        arr = response.get(ARRAY_WRAPPER) or []
+        errors = (
+            arr[0].get("data", {}).get("setEndpointFeatures", {}).get("errors")
+            if arr
+            else None
+        )
+        if errors:
+            _LOGGER.error(
+                "Thermostat control error for %s: %s", device.account_name, errors
+            )
+            raise CannotSetThermostat(
+                f"Amazon rejected {operation_name} for {device.account_name}: {errors}"
+            )
+
+
+def _format_temperature(value: float) -> str:
+    """Format a temperature the way Amazon's mutation expects."""
+    if float(value).is_integer():
+        return str(int(value))
+    return str(value)

--- a/src/aioamazondevices/structures.py
+++ b/src/aioamazondevices/structures.py
@@ -26,7 +26,7 @@ class AmazonDeviceSensor:
     """Amazon device sensor class."""
 
     name: str
-    value: str | int | float
+    value: str | int | float | dict[str, Any]
     error: bool
     error_type: str | None
     error_msg: str | None


### PR DESCRIPTION
```yaml
AmazonDeviceSensor(name='thermostat', value={
'temperatureScale': 'FAHRENHEIT',
'upperSetpoint': 72.0,
'targetSetpoint': 62.0,
'lowerSetpoint': 65.0,
'thermostatMode': 'AUTO',
'supportedModes': ['HEAT', 'COOL', 'AUTO', 'OFF'],
'heatingMinimumTemperature': 40.0,
'heatingMaximumTemperature': 87.0,
'coolingMinimumTemperature': 43.0,
'coolingMaximumTemperature': 90.0,
'temperature': 72.0}
```

fixes #576