### PR TITLE
fix: don't raise NoOnlineDevicesError on AQM-only accounts

### DIFF
--- a/src/aioamazondevices/api.py
+++ b/src/aioamazondevices/api.py
@@ -248,7 +248,6 @@ class AmazonEchoApi:
             await self._media_handler.update_music_providers()
             await self._sequence_handler.update_routines()
             await self._todo_handler.update_lists()
-            await self._init_default_device()
 
             self._last_daily_refresh = datetime.now(UTC)
 
@@ -267,6 +266,12 @@ class AmazonEchoApi:
             # Set device endpoint data
             await self._device_handler.set_device_endpoints_data()
             self._last_endpoint_refresh = datetime.now(UTC)
+
+        # Resolve the default device only once base and endpoint devices are
+        # loaded: sensor-only devices (e.g. Amazon Air Quality Monitor) are
+        # created by set_device_endpoints_data() and would otherwise be missed,
+        # aborting the refresh with NoOnlineDevicesError.
+        await self._init_default_device()
 
     async def get_devices_data(
         self,

--- a/tests/test_refresh_basic_data.py
+++ b/tests/test_refresh_basic_data.py
@@ -1,0 +1,49 @@
+# Copyright 2024 Simone Chemelli and contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for _refresh_basic_data ordering in AmazonEchoApi."""
+
+from collections.abc import Callable
+from unittest.mock import AsyncMock
+
+import pytest
+
+from aioamazondevices.api import AmazonEchoApi
+from aioamazondevices.structures import AmazonDevice
+
+from .const import TEST_SERIAL_1
+
+
+@pytest.mark.anyio
+async def test_refresh_resolves_default_device_from_endpoint_only_account(
+    api: AmazonEchoApi, make_device: Callable[..., AmazonDevice]
+) -> None:
+    """Endpoint-only devices (e.g. Air Quality Monitor) resolve as default device.
+
+    Regression test: the Air Quality Monitor is created by
+    set_device_endpoints_data(), so resolving the default device before that call
+    aborted the whole refresh with NoOnlineDevicesError on accounts without an
+    Echo device.
+    """
+    call_order: list[str] = []
+
+    async def _get_base_devices() -> None:
+        call_order.append("get_base_devices")
+
+    async def _set_device_endpoints_data() -> None:
+        call_order.append("set_device_endpoints_data")
+        api._device_handler._final_devices[TEST_SERIAL_1] = make_device(
+            TEST_SERIAL_1, online=True
+        )
+
+    api._device_handler.get_base_devices = _get_base_devices  # type: ignore[method-assign]
+    api._device_handler.set_device_endpoints_data = _set_device_endpoints_data  # type: ignore[method-assign]
+    api._media_handler.update_music_providers = AsyncMock()  # type: ignore[method-assign]
+    api._sequence_handler.update_routines = AsyncMock()  # type: ignore[method-assign]
+    api._todo_handler.update_lists = AsyncMock()  # type: ignore[method-assign]
+
+    await api._refresh_basic_data()
+
+    assert call_order == ["get_base_devices", "set_device_endpoints_data"]
+    default_device = await api.get_default_device()
+    assert default_device.serial_number == TEST_SERIAL_1


### PR DESCRIPTION
Fixes #1064

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved default-device selection during data refreshes.
  - Devices discovered through endpoint data are now correctly considered, preventing refresh failures and ensuring the appropriate default device is selected.

- **Tests**
  - Added regression coverage for refresh ordering and endpoint-only device discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->